### PR TITLE
refactor: PE-510: remove use of EWA_URL and VDBE_URL env vars

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@persistr/clif": "^1.11.0",
         "@persistr/clif-plugin-settings": "^2.3.1",
         "humanize-duration": "^3.33.0",
+        "jwt-decode": "^4.0.0",
         "luxon": "^3.7.1",
         "smol-toml": "^1.4.1",
         "tiny-spinner": "^2.0.5"
@@ -2965,6 +2966,15 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/keyv": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@persistr/clif": "^1.11.0",
     "@persistr/clif-plugin-settings": "^2.3.1",
     "humanize-duration": "^3.33.0",
+    "jwt-decode": "^4.0.0",
     "luxon": "^3.7.1",
     "smol-toml": "^1.4.1",
     "tiny-spinner": "^2.0.5"

--- a/src/commands/scan.js
+++ b/src/commands/scan.js
@@ -133,8 +133,7 @@ module.exports = {
 
     // Send telemetry: scan started.
     let scanID = undefined
-    const isTelemetryEnabled = telemetry.enabled()
-    if (isTelemetryEnabled) {
+    if (telemetry.enabled) {
       // TODO: Should pass scanID to the server; not read it from the server.
       try {
         const res = await telemetry.send(`scans/started`, {}, { scanners: scanners.map((s) => s.name) })
@@ -157,7 +156,7 @@ module.exports = {
     catch (error) {
       log(`\n${error}`)
       if (!args.QUIET) log('Scan NOT completed!')
-      if (telemetry.enabled()) await telemetry.send(`scans/:scanID/failed`, { scanID })
+      if (telemetry.enabled) await telemetry.send(`scans/:scanID/failed`, { scanID })
       fs.rmSync(tmpdir, { recursive: true, force: true }) // Clean up.
       return 0x10 // exit code
     }
@@ -170,13 +169,13 @@ module.exports = {
     if (outfile) fs.writeFileSync(outfile, JSON.stringify(results.sarif))
 
     // Send telemetry: scan results.
-    if (isTelemetryEnabled && scanID) {
+    if (telemetry.enabled && scanID) {
       await telemetry.sendSensitive(`scans/:scanID/results`, { scanID }, { findings: results.sarif, log: results.log })
     }
 
     // Analyze scan results: group findings by severity level.
     let summary
-    if (isTelemetryEnabled && scanID) {
+    if (telemetry.enabled && scanID) {
       const analysis = await telemetry.receiveSensitive(`scans/:scanID/summary`, { scanID })
       if (!analysis?.summary) throw new Error(`Failed to retrieve analysis summary for scan '${scanID}'`)
       summary = analysis.summary.findingsBySeverity
@@ -185,7 +184,7 @@ module.exports = {
     }
 
     // Send telemetry: scan summary.
-    if (isTelemetryEnabled && scanID) {
+    if (telemetry.enabled && scanID) {
       await telemetry.send(`scans/:scanID/completed`, { scanID }, summary)
     }
 

--- a/src/plugins/telemetry.js
+++ b/src/plugins/telemetry.js
@@ -1,6 +1,6 @@
-const telemetry = require('../telemetry')
+const { Telemetry } = require('../telemetry')
 module.exports = {
   toolbox: {
-    telemetry
+    telemetry: new Telemetry()
   }
 }

--- a/src/telemetry/index.js
+++ b/src/telemetry/index.js
@@ -1,111 +1,125 @@
-const package = require('../../package.json')
+const pkg = require('../../package.json')
 const { DateTime } = require("luxon")
+const { jwtDecode } = require('jwt-decode')
 
-const EWA_URL = process.env.EWA_URL ?? 'https://bff.eurekadevsecops.com'
-const VDBE_URL = process.env.VDBE_URL ?? 'https://vulns.eurekadevsecops.com'
+class Telemetry {
+  #EUREKA_AGENT_TOKEN = process.env.EUREKA_AGENT_TOKEN
+  #USER_AGENT = `RadarCLI/${pkg.version} (${pkg.pkgname}@${pkg.version}; ${process?.platform}-${process?.arch}; ${process?.release?.name}-${process?.version})`
+  #EWA_URL
 
-const USER_AGENT = `Radar/${package.version} (${package.pkgname}@${package.version}; ${process?.platform}-${process?.arch}; ${process?.release?.name}-${process?.version})`
+  constructor() {
+    this.enabled = !!this.#EUREKA_AGENT_TOKEN
+    this.#EWA_URL = this.#claims(this.#EUREKA_AGENT_TOKEN).aud
+  }
 
-const enabled = () => {
-  if (process.env.EUREKA_AGENT_TOKEN) return true
-  return false
-}
-
-const receive = async (path, params, token) => {
-  return fetch(toReceiveURL(path, params), {
-    method: 'GET',
-    headers: {
-      'Authorization': `Bearer ${token ?? process.env.EUREKA_AGENT_TOKEN}`,
-      'User-Agent': USER_AGENT,
-      'Accept': 'application/json'
-    }
-  }).then(async (res) => {    
-      const responseJson = await res.json();
-      return responseJson;
+  async send(path, params, body, token) {
+    return fetch(this.#toPostURL(path, params, token), {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${token ?? this.#EUREKA_AGENT_TOKEN}`,
+        'Content-Type': this.#toContentType(path),
+        'User-Agent': this.#USER_AGENT,
+        'Accept': 'application/json'
+      },
+      body: this.#toBody(path, body)
+    })
+    .then(async (res) => {
+//TODO: Display this on stdout only if --debug option is selected on the cmd line.
+//if (!res.ok) console.log(`POST ${this.#toPostURL(path, params, token)} [${res.status}] ${res.statusText}: ${await res.text()}`)
+      return res
     })
   }
 
-const receiveSensitive = async (path, params) => {
-  return receive(path, params, await token())
-}
-
-const send = async (path, params, body, token) => {
-  return fetch(toPostURL(path, params), {
-    method: 'POST',
-    headers: {
-      'Authorization': `Bearer ${token ?? process.env.EUREKA_AGENT_TOKEN}`,
-      'Content-Type': toContentType(path),
-      'User-Agent': USER_AGENT,
-      'Accept': 'application/json'
-    },
-    body: toBody(path, body)
-  })
-  .then(async (res) => {
-    // TODO: Display this on stdout only if --debug option is selected on the cmd line.
-    // if (!res.ok) console.log(`POST ${toURL(path, params)} [${res.status}] ${res.statusText}: ${await res.text()}`)
-    return res
-  })
-}
-
-const sendSensitive = async (path, params, body) => {
-  return send(path, params, body, await token())
-}
-
-const token = async () => {
-  const response = await fetch(`${EWA_URL}/vdbe/token`, {
-    method: 'POST',
-    headers: {
-      'Authorization': `Bearer ${process.env.EUREKA_AGENT_TOKEN}`,
-      'Content-Type': 'application/json',
-      'User-Agent': USER_AGENT,
-      'Accept': 'application/json'
-    }
-  })
-  if (!response.ok) throw new Error(`Internal Error: Failed to get VDBE auth token from EWA: ${response.statusText}: ${await response.text()}`)
-  const data = await response.json()
-  return data.token
-}
-
-const toPostURL = (path, params) => {
-  if (path === `scans/started`) return `${EWA_URL}/scans/started`
-  if (path === `scans/:scanID/completed`) return `${EWA_URL}/scans/${params.scanID}/completed`
-  if (path === `scans/:scanID/failed`) return `${EWA_URL}/scans/${params.scanID}/completed`
-  if (path === `scans/:scanID/results`) return `${VDBE_URL}/scans/${params.scanID}/results`
-  throw new Error(`Internal Error: Unknown telemetry event: POST ${path}`)
-}
-
-const toReceiveURL = (path, params) => {
-  if (path === `scans/:scanID/summary`) return `${VDBE_URL}/scans/${params.scanID}/summary?profileId=${process.env.EUREKA_PROFILE}`
-  throw new Error(`Internal Error: Unknown telemetry event: GET ${path}`)
-}
-
-const toContentType = (path) => {
-  if (path === `scans/:scanID/log`) return 'text/plain'
-  return 'application/json'
-}
-
-const toBody = (path, body) => {
-  if (path === `scans/started`) body = { ...body, timestamp: DateTime.now().toISO(), profile_id: process.env.EUREKA_PROFILE }
-  if (path === `scans/:scanID/completed`) body = { ...toFindings(body), timestamp: DateTime.now().toISO(), status: 'success', log: { sizeBytes: 0, warnings: 0, errors: 0, link: 'none' }, params: { id: '' }}
-  if (path === `scans/:scanID/failed`) body = { ...body, timestamp: DateTime.now().toISO(), status: 'failure', findings: { total: 0, critical: 0, high: 0, med: 0, low: 0 }, log: { sizeBytes: 0, warnings: 0, errors: 0, link: 'none' }, params: { id: '' }}
-  if (path === `scans/:scanID/results`) body = { findings: body.findings /* SARIF */, profileId: process.env.EUREKA_PROFILE, log: Buffer.from(body.log, 'utf8').toString('base64') }
-  return JSON.stringify(body)
-}
-
-const toFindings = (summary) => ({
-  findings: {
-    total: summary.errors.length + summary.warnings.length + summary.notes.length,
-    critical: 0,
-    high: summary.errors.length,
-    med: summary.warnings.length,
-    low: summary.notes.length
+  async sendSensitive(path, params, body) {
+    return this.send(path, params, body, await this.#token())
   }
-})
+
+  async receive(path, params, token) {
+    return fetch(this.#toReceiveURL(path, params, token), {
+      method: 'GET',
+      headers: {
+        'Authorization': `Bearer ${token ?? this.#EUREKA_AGENT_TOKEN}`,
+        'User-Agent': this.#USER_AGENT,
+        'Accept': 'application/json'
+      }
+    }).then(async (res) => {
+//TODO: Display this on stdout only if --debug option is selected on the cmd line.
+//if (!res.ok) console.log(`GET ${this.#toReceiveURL(path, params, token)} [${res.status}] ${res.statusText}`)
+      return await res.json()
+    })
+  }
+
+  async receiveSensitive(path, params) {
+    return this.receive(path, params, await this.#token())
+  }
+
+  //
+  // private
+  //
+
+  #claims(jwt) {
+    let claims = undefined
+    try { claims = jwtDecode(jwt) } catch (error) {}
+    return claims ?? {}
+  }
+
+  async #token() {
+    const response = await fetch(`${this.#EWA_URL}/vdbe/token`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${this.#EUREKA_AGENT_TOKEN}`,
+        'Content-Type': 'application/json',
+        'User-Agent': this.#USER_AGENT,
+        'Accept': 'application/json'
+      }
+    })
+    if (!response.ok) throw new Error(`Internal Error: Failed to get VDBE auth token from EWA: ${response.statusText}: ${await response.text()}`)
+    const data = await response.json()
+    return data.token
+  }
+
+  #toPostURL(path, params, token) {
+    const claims = this.#claims(token ?? this.#EUREKA_AGENT_TOKEN)
+    if (path === `scans/started`) return `${claims.aud}/scans/started`
+    if (path === `scans/:scanID/completed`) return `${claims.aud}/scans/${params.scanID}/completed`
+    if (path === `scans/:scanID/failed`) return `${claims.aud}/scans/${params.scanID}/completed`
+    if (path === `scans/:scanID/results`) return `${claims.aud}/scans/${params.scanID}/results`
+    throw new Error(`Internal Error: Unknown telemetry event: POST ${path}`)
+  }
+
+  #toReceiveURL(path, params, token) {
+    const claims = this.#claims(token ?? this.#EUREKA_AGENT_TOKEN)
+    if (path === `scans/:scanID/summary`) return `${claims.aud}/scans/${params.scanID}/summary?profileId=${process.env.EUREKA_PROFILE}`
+    throw new Error(`Internal Error: Unknown telemetry event: GET ${path}`)
+  }
+
+  #toContentType(path) {
+    if (path === `scans/:scanID/log`) return 'text/plain'
+    return 'application/json'
+  }
+
+  #toBody(path, body) {
+    if (path === `scans/started`) body = { ...body, timestamp: DateTime.now().toISO(), profile_id: process.env.EUREKA_PROFILE }
+    if (path === `scans/:scanID/completed`) body = { ...this.#toFindings(body), timestamp: DateTime.now().toISO(), status: 'success', log: { sizeBytes: 0, warnings: 0, errors: 0, link: 'none' }, params: { id: '' }}
+    if (path === `scans/:scanID/failed`) body = { ...body, timestamp: DateTime.now().toISO(), status: 'failure', findings: { total: 0, critical: 0, high: 0, med: 0, low: 0 }, log: { sizeBytes: 0, warnings: 0, errors: 0, link: 'none' }, params: { id: '' }}
+    if (path === `scans/:scanID/results`) body = { findings: body.findings /* SARIF */, profileId: process.env.EUREKA_PROFILE, log: Buffer.from(body.log, 'utf8').toString('base64') }
+    return JSON.stringify(body)
+  }
+
+  #toFindings(summary) {
+    return {
+      findings: {
+        total: summary.errors.length + summary.warnings.length + summary.notes.length,
+        critical: 0,
+        high: summary.errors.length,
+        med: summary.warnings.length,
+        low: summary.notes.length
+      }
+    }
+  }
+
+}
 
 module.exports = {
-  enabled,
-  receive, 
-  receiveSensitive,
-  send,
-  sendSensitive
+  Telemetry
 }


### PR DESCRIPTION
These are not needed anymore because both the EWA Credentials token and the VDBE JWT token contain an audience 'aud' claim which points at the base URL of the EWA API and VDBE API services, respectively.

This PR depends on EWA PR 227 (https://github.com/EurekaDevSecOps/app/pull/227) which must be merged first.

Resolves PE-510