### PR TITLE
fix(PE-499): align analysis summary payload with VDBE

### DIFF
--- a/src/commands/scan.js
+++ b/src/commands/scan.js
@@ -180,8 +180,8 @@ module.exports = {
     let summary
     if (telemetry.enabled && scanID) {
       const analysis = await telemetry.receiveSensitive(`scans/:scanID/summary`, { scanID })
-      if (!analysis?.summary) throw new Error(`Failed to retrieve analysis summary for scan '${scanID}'`)
-      summary = analysis.summary.findingsBySeverity
+      if (!analysis?.findingsBySeverity) throw new Error(`Failed to retrieve analysis summary for scan '${scanID}'`)
+      summary = analysis.findingsBySeverity
     } else {
       summary = await SARIF.analysis.summarize(results.sarif, target)
     }


### PR DESCRIPTION
## Changes

- There were changes introduced in https://github.com/EurekaDevSecOps/vdbe/blame/main/app/controllers/scans_controller.ts#L50, that caused the analysis payload to be different than what is being read by the Radar. Causing an error to be thrown