### PR TITLE
refactor(PE-977): Ensure the Azure Devops url is decoded during parsing

### DIFF
--- a/src/util/git/index.js
+++ b/src/util/git/index.js
@@ -20,9 +20,9 @@ function parseAzureDevOpsUrl(originUrl) {
 
   const decodeComponentURI = (value) => {
     try {
-      return decodeURIComponent(value);
+      return decodeURIComponent(value)
     } catch (error) {
-      return value;
+      return value
     }
   }
 

--- a/src/util/git/index.js
+++ b/src/util/git/index.js
@@ -22,7 +22,7 @@ function parseAzureDevOpsUrl(originUrl) {
     try {
       return decodeURIComponent(value)
     } catch (error) {
-      return value
+      throw new Error(`failed decoding Azure DevOps URL component: ${error.message}`)
     }
   }
 

--- a/src/util/git/index.js
+++ b/src/util/git/index.js
@@ -18,7 +18,18 @@ function parseAzureDevOpsUrl(originUrl) {
   const cleanUrl = originUrl.replace(/https:\/\/([^@:]+:)?[^@]+@/, "https://");
   const url = new URL(cleanUrl);
 
-  const pathParts = url.pathname.split("/").filter((p) => p);
+  const decodeComponentURI = (value) => {
+    try {
+      return decodeURIComponent(value);
+    } catch (error) {
+      return value;
+    }
+  }
+
+  const pathParts = url.pathname
+    .split("/")
+    .filter((p) => p)
+    .map((part) => decodeComponentURI(part));
   if (pathParts.length < 4 || pathParts[2] !== "_git") {
     throw new Error(`Invalid Azure DevOps URL format: ${originUrl}`);
   }


### PR DESCRIPTION
[Resolves PE-977](https://linear.app/eureka-devsecops/issue/PE-977/ensure-that-the-repository-name-is-encoded-to-handle-encoded)

## Changes

- Ensure during the manual Azure DevOps URL parsing, it also also decoded with `decodeComponentUri` to prevent encoded characters from being saved into the metadata

Merge with:
https://github.com/EurekaDevSecOps/app/pull/548
https://github.com/EurekaDevSecOps/vdbe/pull/185