### PR TITLE
refactor(PE-827) - refactor/fix vulnerability import

### DIFF
--- a/src/commands/import.js
+++ b/src/commands/import.js
@@ -1,9 +1,12 @@
-const crypto = require('node:crypto')
 const fs = require('node:fs')
 const path = require('node:path')
-const os = require('node:os')
 const SARIF = require('../util/sarif')
-const runner = require('../util/runner')
+const {
+  parseRepositoryValue,
+  parseRepositoryFromSarif
+} = require('../util/repository')
+const { DateTime } = require('luxon')
+
 module.exports = {
   summary: 'import vulnerabilities',
   args: {
@@ -17,11 +20,13 @@ module.exports = {
   options: [
     { name: 'ESCALATE', short: 'e', long: 'escalate', type: 'string', description: 'severities to treat as high/error' },
     { name: 'FORMAT', short: 'f', long: 'format', type: 'string', description: 'severity format' },
-    { name: 'QUIET', short: 'q', long: 'quiet', type: 'boolean', description: 'suppress stdout logging' }
+    { name: 'QUIET', short: 'q', long: 'quiet', type: 'boolean', description: 'suppress stdout logging' },
+    { name: 'REPOSITORY', short: 'r', long: 'repository', type: 'string', description: 'repository in owner[/path]/name format (optional)' }
   ],
   description: `
     Imports vulnerabilities from the input SARIF file given by INPUT argument.
     The SARIF file must have been produced by scanners supported by Radar CLI.
+    The repository must have been added to your Eureka organization.
 
     When quiet mode is selected with the QUIET command-line option, most stdout
     logs are ommitted except for errors that occur with the importing process.
@@ -36,11 +41,11 @@ module.exports = {
         16 - Import aborted due to unexpected error.
   `,
   examples: [
-    '$ radar import scan.sarif ' + '(import findings from SARIF file)'.grey,
-    '$ radar import -f security scan.sarif ' + '(displays findings as high, moderate, and low)'.grey,
-    '$ radar import -f sarif scan.sarif ' + '(displays findings as error, warning, and note)'.grey,
-    '$ radar import -e moderate,low scan.sarif ' + '(treat lower severities as high)'.grey,
-    '$ radar import -f sarif -e warning,note scan.sarif ' + '(treat lower severities as errors)'.grey
+    '$ radar import scan.sarif -r myorg/myproject ' + '(import findings from SARIF file)'.grey,
+    '$ radar import -f security scan.sarif -r myorg/myproject ' + '(displays findings as high, moderate, and low)'.grey,
+    '$ radar import -f sarif scan.sarif -r myorg/myproject ' + '(displays findings as error, warning, and note)'.grey,
+    '$ radar import -e moderate,low scan.sarif -r myorg/myproject ' + '(treat lower severities as high)'.grey,
+    '$ radar import -f sarif -e warning,note scan.sarif -r myorg/myproject' + '(treat lower severities as errors)'.grey
   ],
   run: async (toolbox, args) => {
     const { log, scanners: availableScanners, telemetry } = toolbox
@@ -57,6 +62,9 @@ module.exports = {
       if (args.FORMAT === 'security' && severity !== 'moderate' && severity !== 'low') throw new Error(`Severity to escalate must be 'moderate' or 'low'`)
       if (args.FORMAT === 'sarif' && severity !== 'warning' && severity !== 'note') throw new Error(`Severity to escalate must be 'warning' or 'note'`)
     })
+    if (args.REPOSITORY && !parseRepositoryValue(args.REPOSITORY)) {
+      throw new Error(`REPOSITORY must be in the format 'owner[/path]/name'`)
+    }
 
     // Derive scan parameters.
     const escalations = args.ESCALATE?.split(',').map(severity => {
@@ -83,11 +91,53 @@ module.exports = {
       scanners.push(scanner)
     }
 
-    // Send telemetry: scan started.
+    // use the repository from the CLI if present, otherwise fall back to SARIF
+    const sarifRepository = parseRepositoryFromSarif(results.sarif)
+    const resolvedRepository = args.REPOSITORY
+      ? parseRepositoryValue(args.REPOSITORY)
+      : sarifRepository
+
+    // reject vulnerability import if CLI repository is malformed
+    if (args.REPOSITORY && !resolvedRepository) {
+      throw new Error(`REPOSITORY must be in the format 'owner[/path]/name'`)
+    }
+
+    const importRepoOwner = resolvedRepository?.owner ?? ''
+    const importRepoPath = resolvedRepository?.path ?? ''
+    const importRepoName = resolvedRepository?.name ?? ''
+
+    // construct scan metadata 
+    const scanMetadata = {
+      type: 'git',
+      repo: {
+        url: {
+          origin: '',
+          https: ''
+        },
+        source: {
+          type: '',
+          domain: ''
+        },
+        owner: importRepoOwner,
+        path: importRepoPath,
+        name: importRepoName,
+        abbrevs: 0,
+        contributors: [],
+      },
+      commit: {
+        id: '',
+        time: Date.now(),
+        branch: '',
+        tags: []
+      }
+    }
+
+    // Send telemetry: scan started (stage 1).
     let scanID = undefined
+    const timestamp = DateTime.now().toISO()
     // TODO: Should pass scanID to the server; not read it from the server.
     try {
-      const res = await telemetry.send(`scans/started`, {}, { scanners })
+      const res = await telemetry.send(`scans/started`, {}, { scanners, metadata: scanMetadata, timestamp })
       if (!res.ok) throw new Error(`[${res.status}] ${res.statusText}: ${await res.text()}`)
       const data = await res.json()
       scanID = data.scan_id
@@ -98,6 +148,10 @@ module.exports = {
       return 0x10 // exit code
     }
 
+    // Send telemetry: scan started (stage 2).
+    let res = await telemetry.sendSensitive(`scans/:scanID/started`, { scanID }, { metadata: scanMetadata, timestamp })
+    if (!res.ok) log(`WARNING: Scan started (stage 2) telemetry upload failed: [${res.status}] ${res.statusText}: ${await res.text()}`)
+
     // Transform scan findings: treat warnings and notes as errors, and normalize location paths.
     if (escalations) results.sarif = SARIF.transforms.escalate(results.sarif, escalations)
 
@@ -106,11 +160,12 @@ module.exports = {
 
     // Analyze scan results: group findings by severity level.
     const analysis = await telemetry.receiveSensitive(`scans/:scanID/summary`, { scanID })
+
     if (!analysis?.findingsBySeverity) throw new Error(`Failed to retrieve analysis summary for scan '${scanID}'`)
     const summary = analysis.findingsBySeverity
 
     // Send telemetry: scan summary.
-    await telemetry.send(`scans/:scanID/completed`, { scanID }, summary)
+    await telemetry.send(`scans/:scanID/completed`, { scanID }, { summary })
 
     // Display summarized findings.
     if (!args.QUIET) {

--- a/src/commands/import.js
+++ b/src/commands/import.js
@@ -62,9 +62,9 @@ module.exports = {
       if (args.FORMAT === 'security' && severity !== 'moderate' && severity !== 'low') throw new Error(`Severity to escalate must be 'moderate' or 'low'`)
       if (args.FORMAT === 'sarif' && severity !== 'warning' && severity !== 'note') throw new Error(`Severity to escalate must be 'warning' or 'note'`)
     })
-    if (args.REPOSITORY && !parseRepositoryValue(args.REPOSITORY)) {
-      throw new Error(`REPOSITORY must be in the format 'owner[/path]/name'`)
-    }
+
+    const cliRepository = args.REPOSITORY ? parseRepositoryValue(args.REPOSITORY) : null
+    if (args.REPOSITORY && !cliRepository) throw new Error(`REPOSITORY must be in the format 'owner[/path]/name'`)
 
     // Derive scan parameters.
     const escalations = args.ESCALATE?.split(',').map(severity => {
@@ -93,14 +93,7 @@ module.exports = {
 
     // use the repository from the CLI if present, otherwise fall back to SARIF
     const sarifRepository = parseRepositoryFromSarif(results.sarif)
-    const resolvedRepository = args.REPOSITORY
-      ? parseRepositoryValue(args.REPOSITORY)
-      : sarifRepository
-
-    // reject vulnerability import if CLI repository is malformed
-    if (args.REPOSITORY && !resolvedRepository) {
-      throw new Error(`REPOSITORY must be in the format 'owner[/path]/name'`)
-    }
+    const resolvedRepository = cliRepository ?? sarifRepository
 
     const importRepoOwner = resolvedRepository?.owner ?? ''
     const importRepoPath = resolvedRepository?.path ?? ''

--- a/src/telemetry/index.js
+++ b/src/telemetry/index.js
@@ -132,7 +132,7 @@ class Telemetry {
     if (path === `scans/started`) return `${aud}/scans/started`
     if (path === `scans/:scanID/started`) return `${aud}/scans/${params.scanID}/started`
     if (path === `scans/:scanID/completed`) return `${aud}/scans/${params.scanID}/completed`
-    if (path === `scans/:scanID/failed`) return `${aud}/scans/${params.scanID}/completed`
+    if (path === `scans/:scanID/failed`) return `${aud}/scans/${params.scanID}/failed`
     if (path === `scans/:scanID/results`) return `${aud}/scans/${params.scanID}/results`
     throw new Error(`Internal Error: Unknown telemetry event: POST ${path}`)
   }

--- a/src/util/git/index.js
+++ b/src/util/git/index.js
@@ -14,81 +14,43 @@ function isAzureDevOpsUrl(originUrl) {
 }
 
 function isBitbucketUrl(originUrl) {
-  if (!originUrl) return false
   return originUrl.toLowerCase().includes("bitbucket.org");
-}
-
-function parseSshUrl(originUrl, { user } = {}) {
-  const match = originUrl.match(/^(?:ssh:\/\/)?([^@]+)@([^:/]+)(?::|\/)(.+)$/)
-  if (!match) return null
-  if (user && match[1] !== user) return null
-  return {
-    user: match[1],
-    host: match[2],
-    path: match[3]
-  }
 }
 
 
 /**
- * BitBucket formats:
- * - `http://<user>@bitbucket.org/<workspace>/<repo>`
- * - `https://bitbucket.org/<workspace>/<repo>`
- * - `git@bitbucket.org:<workspace>/<repo>.git`
- * - `ssh://git@bitbucket.org/<workspace>/<repo>.git`
- * - The remote URL for BitBucket repositories may omit or include the .git suffix.
+ * BitBucket format:
+ * - `http://<user>@bitbucket.org/<user>/<project>`
+ * - The remote URL for BitBucket repositories is formatted in http and does not include the .git suffix. 
+ *   We should handle parsing the URL accordingly 
  */
 function parseBitbucketUrl(originUrl) {
-  if (!originUrl) return null
+  if (!originUrl) return null;
+  if (!/^https?:\/\//i.test(originUrl)) return null;
 
-  const parsePathParts = (rawPath) =>
-    rawPath.split('/').filter((p) => p)
-
-  const sshMatch = parseSshUrl(originUrl, { user: 'git' })
-  if (sshMatch) {
-    const host = sshMatch.host
-    const pathParts = parsePathParts(sshMatch.path)
-    if (pathParts.length < 2) return null
-
-    const user = pathParts[0]
-    const project = pathParts[1].replace(/\.git$/i, '')
-    if (!user || !project) return null
-
-    const httpsUrl = `https://${host}/${user}/${project}`
-    return {
-      https: () => httpsUrl,
-      type: 'bitbucket',
-      domain: host,
-      user,
-      project
-    }
-  }
-
-  if (!/^https?:\/\//i.test(originUrl)) return null
-
-  const cleanUrl = originUrl.replace(/^http:\/\//i, 'https://')
-  let url
+  const cleanUrl = originUrl.replace(/^http:\/\//i, "https://");
+  let url;
   try {
-    url = new URL(cleanUrl)
+    url = new URL(cleanUrl);
   } catch (error) {
-    return null
+    return null;
   }
 
-  const pathParts = parsePathParts(url.pathname)
-  if (pathParts.length < 2) return null
+  const pathParts = url.pathname.split("/").filter((p) => p);
+  if (pathParts.length < 2) return null;
 
-  const user = pathParts[0]
-  const project = pathParts[1].replace(/\.git$/i, '')
-  if (!user || !project) return null
+  const user = pathParts[0];
+  const project = pathParts[1].replace(/\.git$/i, "");
+  if (!user || !project) return null;
 
-  const httpsUrl = `https://${url.hostname}/${user}/${project}`
+  const httpsUrl = `https://${url.hostname}/${user}/${project}`;
   return {
     https: () => httpsUrl,
-    type: 'bitbucket',
+    type: "bitbucket",
     domain: url.hostname,
     user,
-    project
-  }
+    project,
+  };
 }
 
 /**

--- a/src/util/repository.js
+++ b/src/util/repository.js
@@ -1,0 +1,64 @@
+const parseRepositorySegments = (segments) => {
+  if (!Array.isArray(segments) || segments.length < 2) return null
+  if (segments.some((segment) => !segment)) return null
+
+  const segmentFormat = /^[a-zA-Z0-9_.-]+$/
+
+  if (segments.some((segment) => !segmentFormat.test(segment))) return null
+  const owner = segments[0]
+  const name = segments[segments.length - 1]
+  const path = segments.length > 2 ? segments.slice(1, -1).join('/') : ''
+
+  const fullName = path ? `${owner}/${path}/${name}` : `${owner}/${name}`
+
+  return { fullName, owner, path, name }
+}
+
+const parseRepositoryValue = (value) => {
+  if (!value) return null
+  const segments = value.split('/')
+
+  return parseRepositorySegments(segments)
+}
+
+const parseRepositoryFromSarif = (sarif) => {
+  let resolved = null
+  for (const run of sarif?.runs ?? []) {
+    const repo =
+      run?.tool?.driver?.properties?.repository ??
+      run?.properties?.repository
+    if (!repo) continue
+    if (typeof repo?.owner !== 'string' || typeof repo?.name !== 'string') continue
+
+    const owner = repo.owner.trim()
+    const name = repo.name.trim()
+    if (!owner || !name) continue
+
+    const path = typeof repo.path === 'string' ? repo.path.trim() : ''
+    const fullName = path ? `${owner}/${path}/${name}` : `${owner}/${name}`
+
+    const current = { fullName, owner, path, name }
+
+    if (!resolved) {
+      resolved = current
+      continue
+    }
+    if (
+      resolved.owner !== current.owner ||
+      resolved.path !== current.path ||
+      resolved.name !== current.name
+    ) {
+      throw new Error(
+        `SARIF runs contain conflicting repository metadata: ` +
+        `found '${resolved.fullName}' and '${current.fullName}'`
+      )
+    }
+  }
+  return resolved
+}
+
+module.exports = {
+  parseRepositorySegments,
+  parseRepositoryValue,
+  parseRepositoryFromSarif
+}

--- a/src/util/repository.js
+++ b/src/util/repository.js
@@ -16,7 +16,7 @@ const parseRepositorySegments = (segments) => {
 
 const parseRepositoryValue = (value) => {
   if (!value) return null
-  const segments = value.split('/')
+  const segments = value.split('/').map((segment) => segment.trim())
 
   return parseRepositorySegments(segments)
 }


### PR DESCRIPTION
[Resolves PE-827](https://linear.app/eureka-devsecops/issue/PE-827/refactor-import-vulnerabilities-for-radar-cli)

Due to the changes since the deprecation of profiles, the radarctl vulnerability import feature has not been working correctly

## Changes 
- The import feature now reads for the repository metadata from the SARIF to ensure that there is an associated repository for when the findings are uploaded to the Eureka DevSecOps platform 
- Added an optional CLI flag that allows overriding of the SARIF's repository name/metadata if required

## Notes

- For import to occur successfully, ensure that the *repository* associated to the SARIF has been added to the Eureka DevSecOps platform, otherwise the import will fail
- These changes correspond with changes in the csv2sarif converter as well, to ensure that SARIF findings that are converted from reports will continue the necessary repository metadata.