### PR TITLE
refactor(PE-991) - Ensure the 'path' field is correctly parsed in ADO repository URLs

### DIFF
--- a/src/util/git/index.js
+++ b/src/util/git/index.js
@@ -72,9 +72,9 @@ function parseAzureDevOpsUrl(originUrl) {
 
   const decodeComponentURI = (value) => {
     try {
-      return decodeURIComponent(value);
+      return decodeURIComponent(value)
     } catch (error) {
-      return value;
+      return value
     }
   }
 

--- a/src/util/git/index.js
+++ b/src/util/git/index.js
@@ -70,45 +70,20 @@ function parseAzureDevOpsUrl(originUrl) {
     }
   }
 
-  const parsePathParts = (rawPath) =>
-    rawPath
-      .split('/')
-      .filter((p) => p)
-      .map((part) => decodeComponentURI(part))
-
-  const sshMatch = parseSshUrl(originUrl, { user: 'git' })
-  if (sshMatch) {
-    const host = sshMatch.host
-    let pathParts = parsePathParts(sshMatch.path)
-    if (pathParts[0] === 'v3') pathParts = pathParts.slice(1)
-    if (pathParts.length < 3) {
-      throw new Error(`Invalid Azure DevOps URL format: ${originUrl}`)
-    }
-
-    const [org, project, repo] = pathParts
-    const https =
-      host.includes('visualstudio.com')
-        ? `https://${org}.visualstudio.com/${project}/_git/${repo}`
-        : `https://dev.azure.com/${org}/${project}/_git/${repo}`
-
-    return {
-      https: () => https,
-      type: 'azure',
-      domain: host,
-      // project name
-      user: project,
-      // repo name
-      project: repo
+  const decodeComponentURI = (value) => {
+    try {
+      return decodeURIComponent(value);
+    } catch (error) {
+      return value;
     }
   }
 
-  // Strip credentials from URL
-  const cleanUrl = originUrl.replace(/https:\/\/([^@:]+:)?[^@]+@/, 'https://')
-  const url = new URL(cleanUrl)
-
-  const pathParts = parsePathParts(url.pathname)
-  if (pathParts.length < 4 || pathParts[2] !== '_git') {
-    throw new Error(`Invalid Azure DevOps URL format: ${originUrl}`)
+  const pathParts = url.pathname
+    .split("/")
+    .filter((p) => p)
+    .map((part) => decodeComponentURI(part));
+  if (pathParts.length < 4 || pathParts[2] !== "_git") {
+    throw new Error(`Invalid Azure DevOps URL format: ${originUrl}`);
   }
 
   return {

--- a/src/util/git/index.js
+++ b/src/util/git/index.js
@@ -74,7 +74,7 @@ function parseAzureDevOpsUrl(originUrl) {
     try {
       return decodeURIComponent(value)
     } catch (error) {
-      return value
+      throw new Error(`failed decoding Azure DevOps URL component: ${error.message}`)
     }
   }
 


### PR DESCRIPTION
[Resolves PE-911](https://linear.app/eureka-devsecops/issue/PE-991/ensure-the-path-metadata-field-is-correctly-mapped-during-azure-devops)

## Changes 

- Ensure the Azure DevOps project is parsed and mapped correctly from the URL to the `path` metadata