### PR TITLE
refactor(PE-991) - Ensure the 'path' field is correctly parsed in ADO repository URLs

### DIFF
--- a/src/util/git/index.js
+++ b/src/util/git/index.js
@@ -14,43 +14,81 @@ function isAzureDevOpsUrl(originUrl) {
 }
 
 function isBitbucketUrl(originUrl) {
+  if (!originUrl) return false
   return originUrl.toLowerCase().includes("bitbucket.org");
+}
+
+function parseSshUrl(originUrl, { user } = {}) {
+  const match = originUrl.match(/^(?:ssh:\/\/)?([^@]+)@([^:/]+)(?::|\/)(.+)$/)
+  if (!match) return null
+  if (user && match[1] !== user) return null
+  return {
+    user: match[1],
+    host: match[2],
+    path: match[3]
+  }
 }
 
 
 /**
- * BitBucket format:
- * - `http://<user>@bitbucket.org/<user>/<project>`
- * - The remote URL for BitBucket repositories is formatted in http and does not include the .git suffix. 
- *   We should handle parsing the URL accordingly 
+ * BitBucket formats:
+ * - `http://<user>@bitbucket.org/<workspace>/<repo>`
+ * - `https://bitbucket.org/<workspace>/<repo>`
+ * - `git@bitbucket.org:<workspace>/<repo>.git`
+ * - `ssh://git@bitbucket.org/<workspace>/<repo>.git`
+ * - The remote URL for BitBucket repositories may omit or include the .git suffix.
  */
 function parseBitbucketUrl(originUrl) {
-  if (!originUrl) return null;
-  if (!/^https?:\/\//i.test(originUrl)) return null;
+  if (!originUrl) return null
 
-  const cleanUrl = originUrl.replace(/^http:\/\//i, "https://");
-  let url;
-  try {
-    url = new URL(cleanUrl);
-  } catch (error) {
-    return null;
+  const parsePathParts = (rawPath) =>
+    rawPath.split('/').filter((p) => p)
+
+  const sshMatch = parseSshUrl(originUrl, { user: 'git' })
+  if (sshMatch) {
+    const host = sshMatch.host
+    const pathParts = parsePathParts(sshMatch.path)
+    if (pathParts.length < 2) return null
+
+    const user = pathParts[0]
+    const project = pathParts[1].replace(/\.git$/i, '')
+    if (!user || !project) return null
+
+    const httpsUrl = `https://${host}/${user}/${project}`
+    return {
+      https: () => httpsUrl,
+      type: 'bitbucket',
+      domain: host,
+      user,
+      project
+    }
   }
 
-  const pathParts = url.pathname.split("/").filter((p) => p);
-  if (pathParts.length < 2) return null;
+  if (!/^https?:\/\//i.test(originUrl)) return null
 
-  const user = pathParts[0];
-  const project = pathParts[1].replace(/\.git$/i, "");
-  if (!user || !project) return null;
+  const cleanUrl = originUrl.replace(/^http:\/\//i, 'https://')
+  let url
+  try {
+    url = new URL(cleanUrl)
+  } catch (error) {
+    return null
+  }
 
-  const httpsUrl = `https://${url.hostname}/${user}/${project}`;
+  const pathParts = parsePathParts(url.pathname)
+  if (pathParts.length < 2) return null
+
+  const user = pathParts[0]
+  const project = pathParts[1].replace(/\.git$/i, '')
+  if (!user || !project) return null
+
+  const httpsUrl = `https://${url.hostname}/${user}/${project}`
   return {
     https: () => httpsUrl,
-    type: "bitbucket",
+    type: 'bitbucket',
     domain: url.hostname,
     user,
-    project,
-  };
+    project
+  }
 }
 
 /**

--- a/src/util/git/index.js
+++ b/src/util/git/index.js
@@ -116,7 +116,7 @@ function parseAzureDevOpsUrl(originUrl) {
     type: 'azure',
     domain: url.hostname,
     // project name
-    user: pathParts[1],
+    user: `${pathParts[0]}/${pathParts[1]}`, 
     // repo name
     project: pathParts[3]
   }


### PR DESCRIPTION
[Resolves PE-911](https://linear.app/eureka-devsecops/issue/PE-991/ensure-the-path-metadata-field-is-correctly-mapped-during-azure-devops)

## Changes 

- Ensure the Azure DevOps project is parsed and mapped correctly from the URL to the `path` metadata