### PR TITLE
fix(PE-1068): fix sbom generation permissions write errors in CI/CD 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,11 +2,3 @@
 node_modules
 .vscode/
 .env
-.npmrc
-test.sarif
-AGENTS.md
-juice-shop
-radar-test
-myprojectinasubgroup
-Netcore
-*run.local.sh

--- a/sbom/cdxgen/run.sh
+++ b/sbom/cdxgen/run.sh
@@ -30,6 +30,7 @@ fi
 docker run \
   --cidfile "$3/cdxgen.cid" \
   --rm \
+  --user 0:0 \
   -v "$1:/src:ro" \
   -v "$3:/output:rw" \
   --entrypoint sh \

--- a/sbom/spdx/run.sh
+++ b/sbom/spdx/run.sh
@@ -46,6 +46,7 @@ convert_with_docker()
     $PLATFORM_ARGS \
     --cidfile "$OUTPUT/spdx.cid" \
     --rm \
+    --user 0:0 \
     -v "$OUTPUT:/output:rw" \
     "$IMAGE" \
     convert \

--- a/src/util/ci.js
+++ b/src/util/ci.js
@@ -9,6 +9,11 @@ const CICD_PROVIDERS = {
     env: 'BITBUCKET_CLONE_DIR',
     value: 'bitbucket'
   },
+  GITHUB: {
+    label: 'GitHub',
+    env: 'GITHUB_WORKSPACE',
+    value: 'github'
+  },
   GITLAB: {
     label: 'GitLab',
     env: 'CI_PROJECT_DIR',
@@ -19,8 +24,13 @@ const CICD_PROVIDERS = {
 const getBitbucketCloneDir = () =>
   getEnvValue(process.env[CICD_PROVIDERS.BITBUCKET.env])
 
+const getGithubCloneDir = () =>
+  getEnvValue(process.env[CICD_PROVIDERS.GITHUB.env])
+
 const getGitlabCloneDir = () =>
   getEnvValue(process.env[CICD_PROVIDERS.GITLAB.env])
+
+const isGithubActions = () => !!process.env.GITHUB_ACTIONS
 
 const isGitlabCi = () => !!process.env.GITLAB_CI
 
@@ -36,6 +46,10 @@ const getCiProvider = () => {
   if (getBitbucketCloneDir() || isBitbucketCi()) {
     return CICD_PROVIDERS.BITBUCKET.value
   }
+  // GitHub Actions provides GITHUB_WORKSPACE for the repository checkout path
+  if (getGithubCloneDir() || isGithubActions()) {
+    return CICD_PROVIDERS.GITHUB.value
+  }
   // GitLab CI provides CI_PROJECT_DIR for the repository checkout path
   if (getGitlabCloneDir() || isGitlabCi()) {
     return CICD_PROVIDERS.GITLAB.value
@@ -48,6 +62,8 @@ const getCloneDir = (provider = getCiProvider()) => {
   switch (provider) {
     case CICD_PROVIDERS.BITBUCKET.value:
       return getBitbucketCloneDir()
+    case CICD_PROVIDERS.GITHUB.value:
+      return getGithubCloneDir()
     case CICD_PROVIDERS.GITLAB.value:
       return getGitlabCloneDir()
     case 'default':
@@ -59,8 +75,10 @@ const getCloneDir = (provider = getCiProvider()) => {
 module.exports = {
   CICD_PROVIDERS,
   getBitbucketCloneDir,
+  getGithubCloneDir,
   getGitlabCloneDir,
   isBitbucketCi,
+  isGithubActions,
   isGitlabCi,
   getCiProvider,
   getCloneDir

--- a/src/util/paths.js
+++ b/src/util/paths.js
@@ -35,32 +35,21 @@ const resolveScanTarget = (target) => {
   const provider = getCiProvider()
   const cloneDir = getCloneDir(provider)
 
-  switch (provider) {
-    case CICD_PROVIDERS.BITBUCKET.value:
-      assertCloneDir({
-        cloneDir,
-        label: CICD_PROVIDERS.BITBUCKET.env,
-        provider: CICD_PROVIDERS.BITBUCKET.label
-      })
-      return resolveWithinCloneDir({
-        target,
-        cloneDir,
-        label: CICD_PROVIDERS.BITBUCKET.env
-      })
-    case CICD_PROVIDERS.GITLAB.value:
-      assertCloneDir({
-        cloneDir,
-        label: CICD_PROVIDERS.GITLAB.env,
-        provider: CICD_PROVIDERS.GITLAB.label
-      })
-      return resolveWithinCloneDir({
-        target,
-        cloneDir,
-        label: CICD_PROVIDERS.GITLAB.env
-      })
-    case 'default':
-    default:
-      break
+  const providerConfig = Object.values(CICD_PROVIDERS).find(
+    ({ value }) => value === provider
+  )
+
+  if (providerConfig) {
+    assertCloneDir({
+      cloneDir,
+      label: providerConfig.env,
+      provider: providerConfig.label
+    })
+    return resolveWithinCloneDir({
+      target,
+      cloneDir,
+      label: providerConfig.env
+    })
   }
 
   // if no provider or target is set, default to current working directory
@@ -71,20 +60,15 @@ const resolveScanTarget = (target) => {
 const resolveScansDir = () => {
   const provider = getCiProvider()
   const cloneDir = getCloneDir(provider)
+  const providerConfig = Object.values(CICD_PROVIDERS).find(
+    ({ value }) => value === provider
+  )
 
-  if (provider === CICD_PROVIDERS.BITBUCKET.value) {
+  if (providerConfig) {
     assertCloneDir({
       cloneDir,
-      label: CICD_PROVIDERS.BITBUCKET.env,
-      provider: CICD_PROVIDERS.BITBUCKET.label
-    })
-  }
-
-  if (provider === CICD_PROVIDERS.GITLAB.value) {
-    assertCloneDir({
-      cloneDir,
-      label: CICD_PROVIDERS.GITLAB.env,
-      provider: CICD_PROVIDERS.GITLAB.label
+      label: providerConfig.env,
+      provider: providerConfig.label
     })
   }
 


### PR DESCRIPTION
## Issue
Resolves [PE-1068](https://linear.app/eureka-devsecops/issue/PE-1068/fix-sbom-files-not-writing-due-to-permission-errors-in-cicd-pipelines)

## Changes
- Add GitHub Actions as a supported CI provider for scan path resolution
- Resolve scan temp output under the CI workspace for all supported providers
- Add `--user 0:0` flag to run the sbom docker commands as root, due to write permission errors in CI/CD pipelines 