### PR TITLE
refactor(PE-1070): emit radar exitCode to scanCompleted telemetry call

### DIFF
--- a/src/commands/scan.js
+++ b/src/commands/scan.js
@@ -288,9 +288,24 @@ module.exports = {
       summary = await SARIF.analysis.summarize(results.sarif, target)
     }
 
+    // Determine the correct exit code.
+    let exitCode = 0
+    if (!summary.errors.length && !summary.warnings.length && !summary.notes.length) {
+      // No vulnerabilities.
+      exitCode = 0
+    } else if (args.THRESHOLD) {
+      // Set the exit code to 8 if there are any vulnerabilities with severities at or above the given threshold.
+      if (is_error(args.THRESHOLD) && summary.errors.length > 0) exitCode = 0x8
+      if (is_warning(args.THRESHOLD) && summary.warnings.length > 0) exitCode = 0x8
+      if (is_note(args.THRESHOLD) && summary.notes.length > 0) exitCode = 0x8
+    } else {
+      // Set the exit code to 8 if there are any vulnerabilities.
+      exitCode = 0x8
+    }
+
     // Send telemetry: scan summary.
     if (telemetry.enabled && scanID && !args.LOCAL) {
-      const res = await telemetry.send(`scans/:scanID/completed`, { scanID }, { summary })
+      const res = await telemetry.send(`scans/:scanID/completed`, { scanID }, { summary, scanExitCode: exitCode })
       if (!res.ok) log(`WARNING: Scan status (completed) telemetry upload failed: [${res.status}] ${res.statusText}: ${await res.text()}`)
     }
 
@@ -305,21 +320,6 @@ module.exports = {
     // Display link to scan results in the dashboard.
     if (telemetry.enabled && scanURL && !args.QUIET) {
       log(`View scan findings in the Eureka dashboard: ${scanURL}`)
-    }
-
-    // Determine the correct exit code.
-    let exitCode = 0
-    if (!summary.errors.length && !summary.warnings.length && !summary.notes.length) {
-      // No vulnerabilities.
-      exitCode = 0
-    } else if (args.THRESHOLD) {
-      // Set the exit code to 8 if there are any vulnerabilities with severities at or above the given threshold.
-      if (is_error(args.THRESHOLD) && summary.errors.length > 0) exitCode = 0x8
-      if (is_warning(args.THRESHOLD) && summary.warnings.length > 0) exitCode = 0x8
-      if (is_note(args.THRESHOLD) && summary.notes.length > 0) exitCode = 0x8
-    } else {
-      // Set the exit code to 8 if there are any vulnerabilities.
-      exitCode = 0x8
     }
 
     // Display the exit code.

--- a/src/telemetry/index.js
+++ b/src/telemetry/index.js
@@ -152,7 +152,7 @@ class Telemetry {
   #toBody(path, body) {
     if (path === `scans/started`) body = { ...body }
     if (path === `scans/:scanID/started`) body = { ...body }
-    if (path === `scans/:scanID/completed`) body = { ...this.#toFindings(body.summary), timestamp: DateTime.now().toISO(), status: 'success', log: { sizeBytes: 0, warnings: 0, errors: 0, link: 'none' }, params: { id: '' }}
+    if (path === `scans/:scanID/completed`) body = { ...this.#toFindings(body.summary), timestamp: DateTime.now().toISO(), status: 'success', log: { sizeBytes: 0, warnings: 0, errors: 0, link: 'none' }, params: { id: '' }, scanExitCode: body.scanExitCode }
     if (path === `scans/:scanID/failed`) body = { ...body, timestamp: DateTime.now().toISO(), status: 'failure', findings: { total: 0, critical: 0, high: 0, med: 0, low: 0 }, log: { sizeBytes: 0, warnings: 0, errors: 0, link: 'none' }, params: { id: '' }}
     if (path === `scans/:scanID/results`) body = { findings: body.findings /* SARIF */, log: Buffer.from(body.log, 'utf8').toString('base64'), sboms: body.sboms }
     return JSON.stringify(body)


### PR DESCRIPTION
## Issue
Resolves PE-1070

## Changes
- Compute the scan exit code before sending completion telemetry
- Include scanExitCode in the completed telemetry payload
-  Preserve existing CLI exit-code behavior while reporting the final status upstream

Merge with associated github check work