### PR TITLE
feat(PE-1085): add diff-aware scan filtering with --diff flag

### DIFF
--- a/src/commands/scan.js
+++ b/src/commands/scan.js
@@ -5,6 +5,7 @@ const SARIF = require('../util/sarif')
 const runner = require('../util/runner')
 const paths = require('../util/paths')
 const SBOM = require('../util/sbom')
+const { execFileSync } = require('node:child_process')
 const { DateTime } = require('luxon')
 
 function is_error(threshold) {
@@ -245,7 +246,7 @@ module.exports = {
 
       // Filter findings to only those on changed lines, if a base ref was provided.
       if (args.DIFF) {
-        const diffOutput = '' // TODO: run git diff args.DIFF...HEAD
+        const diffOutput = execFileSync('git', ['diff', `${args.DIFF}...HEAD`], { cwd: target }).toString()
         const diffRanges = {} // TODO: parse diff into { file: [[start, end]] }
         SARIF.transforms.filterByDiff(results.sarif, diffRanges)
       }

--- a/src/commands/scan.js
+++ b/src/commands/scan.js
@@ -43,7 +43,7 @@ module.exports = {
     { name: 'QUIET', short: 'q', long: 'quiet', type: 'boolean', description: 'suppress stdout logging' },
     { name: 'SCANNERS', short: 's', long: 'scanners', type: 'string', description: 'list of scanners to use' },
     { name: 'SKIP_SBOM', short: 'B', long: 'skipSbom', type: 'bool', description: 'skip SBOM generation' },
-    { name: 'DIFF', long: 'diff', type: 'string', description: 'base ref to filter findings by changed lines (e.g. main)' },
+    { name: 'DIFF', short: 'D', long: 'diff', type: 'string', description: 'base ref to filter findings by changed lines (e.g. main)' },
     { name: 'THRESHOLD', short: 't', long: 'threshold', type: 'string', description: 'severity threshold for non-zero exit code' }
   ],
   description: `

--- a/src/commands/scan.js
+++ b/src/commands/scan.js
@@ -43,7 +43,7 @@ module.exports = {
     { name: 'QUIET', short: 'q', long: 'quiet', type: 'boolean', description: 'suppress stdout logging' },
     { name: 'SCANNERS', short: 's', long: 'scanners', type: 'string', description: 'list of scanners to use' },
     { name: 'SKIP_SBOM', short: 'B', long: 'skipSbom', type: 'bool', description: 'skip SBOM generation' },
-    { name: 'DIFF', short: 'D', long: 'diff', type: 'string', description: 'base ref to filter findings by changed lines (e.g. main)' },
+    { name: 'DIFF', short: 'g', long: 'diff', type: 'string', description: 'base ref to filter findings by changed lines (e.g. main)' },
     { name: 'THRESHOLD', short: 't', long: 'threshold', type: 'string', description: 'severity threshold for non-zero exit code' }
   ],
   description: `
@@ -246,6 +246,7 @@ module.exports = {
       SARIF.transforms.normalize(results.sarif, target, metadata, git.root(target))
 
       // Filter findings to only those on changed lines, if a base ref was provided.
+      // Runs after normalize so the SARIF URIs match the paths from `git diff`.
       if (args.DIFF) {
         const diffOutput = execFileSync('git', ['diff', `${args.DIFF}...HEAD`], { cwd: target }).toString()
         const diffRanges = parseDiff(diffOutput)

--- a/src/commands/scan.js
+++ b/src/commands/scan.js
@@ -6,6 +6,7 @@ const runner = require('../util/runner')
 const paths = require('../util/paths')
 const SBOM = require('../util/sbom')
 const { execFileSync } = require('node:child_process')
+const parseDiff = require('../util/git/diff')
 const { DateTime } = require('luxon')
 
 function is_error(threshold) {
@@ -247,7 +248,7 @@ module.exports = {
       // Filter findings to only those on changed lines, if a base ref was provided.
       if (args.DIFF) {
         const diffOutput = execFileSync('git', ['diff', `${args.DIFF}...HEAD`], { cwd: target }).toString()
-        const diffRanges = {} // TODO: parse diff into { file: [[start, end]] }
+        const diffRanges = parseDiff(diffOutput)
         SARIF.transforms.filterByDiff(results.sarif, diffRanges)
       }
 

--- a/src/commands/scan.js
+++ b/src/commands/scan.js
@@ -41,6 +41,7 @@ module.exports = {
     { name: 'QUIET', short: 'q', long: 'quiet', type: 'boolean', description: 'suppress stdout logging' },
     { name: 'SCANNERS', short: 's', long: 'scanners', type: 'string', description: 'list of scanners to use' },
     { name: 'SKIP_SBOM', short: 'B', long: 'skipSbom', type: 'bool', description: 'skip SBOM generation' },
+    { name: 'DIFF', long: 'diff', type: 'string', description: 'base ref to filter findings by changed lines (e.g. main)' },
     { name: 'THRESHOLD', short: 't', long: 'threshold', type: 'string', description: 'severity threshold for non-zero exit code' }
   ],
   description: `
@@ -241,6 +242,13 @@ module.exports = {
       // Transform scan findings: treat warnings and notes as errors, and normalize location paths.
       if (escalations) results.sarif = SARIF.transforms.escalate(results.sarif, escalations)
       SARIF.transforms.normalize(results.sarif, target, metadata, git.root(target))
+
+      // Filter findings to only those on changed lines, if a base ref was provided.
+      if (args.DIFF) {
+        const diffOutput = '' // TODO: run git diff args.DIFF...HEAD
+        const diffRanges = {} // TODO: parse diff into { file: [[start, end]] }
+        SARIF.transforms.filterByDiff(results.sarif, diffRanges)
+      }
 
       // Scan target for @eureka-radar ignore directives and embed them in the SARIF.
       // Must run after normalize so file paths match the normalized URIs in results.

--- a/src/util/git/diff.js
+++ b/src/util/git/diff.js
@@ -1,0 +1,46 @@
+const HUNK_HEADER = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/
+
+module.exports = (diffOutput) => {
+  const ranges = new Map()
+  let currentFile = null
+  let lineNumber = 0
+
+  for (const line of diffOutput.split('\n')) {
+    if (line.startsWith('diff --git ')) {
+      currentFile = null
+      lineNumber = 0
+      continue
+    }
+
+    if (line.startsWith('+++ b/')) {
+      currentFile = line.slice(6)
+      if (!ranges.has(currentFile)) ranges.set(currentFile, [])
+      continue
+    }
+
+    const hunkMatch = line.match(HUNK_HEADER)
+    if (hunkMatch) {
+      lineNumber = parseInt(hunkMatch[1], 10)
+      continue
+    }
+
+    if (!currentFile || lineNumber === 0) continue
+
+    if (line.startsWith('+')) {
+      const fileRanges = ranges.get(currentFile)
+      const last = fileRanges[fileRanges.length - 1]
+      if (last && last[1] === lineNumber - 1) {
+        last[1] = lineNumber
+      } else {
+        fileRanges.push([lineNumber, lineNumber])
+      }
+      lineNumber++
+    } else if (line.startsWith('-')) {
+      // Deleted line — doesn't exist in new file, don't advance line counter
+    } else {
+      lineNumber++
+    }
+  }
+
+  return ranges
+}

--- a/src/util/git/diff.js
+++ b/src/util/git/diff.js
@@ -1,5 +1,6 @@
 const HUNK_HEADER = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/
 
+// Returns Map<filePath, [startLine, endLine][]> of added-line ranges in the new file.
 module.exports = (diffOutput) => {
   const ranges = new Map()
   let currentFile = null

--- a/src/util/sarif/index.js
+++ b/src/util/sarif/index.js
@@ -2,6 +2,7 @@ module.exports = {
   transforms: {
     escalate: require('./transforms/escalate'),
     embedDirectives: require('./transforms/embed_directives'),
+    filterByDiff: require('./transforms/filter_by_diff'),
     merge: require('./transforms/merge'),
     normalize: require('./transforms/normalize')
   },

--- a/src/util/sarif/transforms/filter_by_diff.js
+++ b/src/util/sarif/transforms/filter_by_diff.js
@@ -3,7 +3,7 @@ module.exports = (sarif, diffRanges) => {
     if (!run.results) continue
     run.results = run.results.filter(result => {
       if (!result.locations) return false
-      return result.locations.some(loc => {
+      return result.locations.every(loc => {
         const uri = loc.physicalLocation?.artifactLocation?.uri
         const line = loc.physicalLocation?.region?.startLine
         if (!uri || !line) return false

--- a/src/util/sarif/transforms/filter_by_diff.js
+++ b/src/util/sarif/transforms/filter_by_diff.js
@@ -2,14 +2,15 @@ module.exports = (sarif, diffRanges) => {
   for (const run of sarif.runs) {
     if (!run.results) continue
     run.results = run.results.filter(result => {
-      const uri = result.locations?.[0]?.physicalLocation?.artifactLocation?.uri
-      const line = result.locations?.[0]?.physicalLocation?.region?.startLine
-      if (!uri || !line) return false
-
-      const ranges = diffRanges.get(uri)
-      if (!ranges) return false
-
-      return ranges.some(([start, end]) => line >= start && line <= end)
+      if (!result.locations) return false
+      return result.locations.some(loc => {
+        const uri = loc.physicalLocation?.artifactLocation?.uri
+        const line = loc.physicalLocation?.region?.startLine
+        if (!uri || !line) return false
+        const ranges = diffRanges.get(uri)
+        if (!ranges) return false
+        return ranges.some(([start, end]) => line >= start && line <= end)
+      })
     })
   }
   return sarif

--- a/src/util/sarif/transforms/filter_by_diff.js
+++ b/src/util/sarif/transforms/filter_by_diff.js
@@ -1,0 +1,16 @@
+module.exports = (sarif, diffRanges) => {
+  for (const run of sarif.runs) {
+    if (!run.results) continue
+    run.results = run.results.filter(result => {
+      const uri = result.locations?.[0]?.physicalLocation?.artifactLocation?.uri
+      const line = result.locations?.[0]?.physicalLocation?.region?.startLine
+      if (!uri || !line) return false
+
+      const ranges = diffRanges.get(uri)
+      if (!ranges) return false
+
+      return ranges.some(([start, end]) => line >= start && line <= end)
+    })
+  }
+  return sarif
+}


### PR DESCRIPTION
 ## Summary
  - Add `--diff` CLI flag that accepts a base ref (e.g. `main`) and filters scan findings to only lines changed between the base and HEAD
  - Scan still runs against the full codebase; the filter is applied post-scan to scope results to the diff
  - Existing full-scan behavior is unchanged when `--diff` is not provided

  ## Changes
  - `src/commands/scan.js` — new `--diff` option, wired between normalize and embed directives transforms
  - `src/util/git/diff.js` — parses unified diff output into a map of changed line ranges per file
  - `src/util/sarif/transforms/filter_by_diff.js` — filters SARIF findings by intersection with changed line ranges
  - `src/util/sarif/index.js` — registers the new transform

  ## Test plan 
  - [ ] Run `radar scan -s opengrep .` on main — should show all findings (eval, XSS, CSRF)
  - [ ] Run `radar scan -s opengrep --diff main .` on fix branch — should show only XSS on line 17 (eval fixed, CSRF filtered out)
  - [ ] Run `radar scan .` without `--diff` — verify existing behavior is unchanged
  - [ ] Test with multi-file and multi-hunk diffs
  - [ ] Test with `.patch` file format input


## Demo
### Test repo:

https://github.com/eu-lee/vuln-app/pull/1/changes

### Before
`radar scan -s opengrep .` on main:
<img width="1005" height="394" alt="image" src="https://github.com/user-attachments/assets/81651e0b-edfa-42aa-ae61-708969da0ab5" />

### After
`radar scan -s opengrep --diff main .` on fix branch:
<img width="1005" height="246" alt="image" src="https://github.com/user-attachments/assets/49717c09-e3c5-4772-8295-960321ecff0e" />
