### PR TITLE
fix: correct semgrep image name and Cmd+C support

### DIFF
--- a/scanners/semgrep/run.sh
+++ b/scanners/semgrep/run.sh
@@ -8,13 +8,22 @@ set -e
 # $3 - Path to the output folder where scan results should be stored
 ###
 
-
 # Expand relative paths
 APP_DIR=$(cd $1; pwd)
 CFG_DIR=$(cd $2; pwd)
 OUT_DIR=$(cd $3; pwd)
 
-docker run --rm \
+trap cleanup TERM INT
+
+cleanup()
+{
+  PID=$(cat "${OUT_DIR}/semgrep.cid")
+  docker stop $PID
+  rm "${OUT_DIR}/semgrep.cid"
+  exit 1
+}
+
+docker run --cidfile "${OUT_DIR}/semgrep.cid" --rm \
     -v "${APP_DIR}":/home/luser/app \
     -v "${CFG_DIR}":/tmp/radar-input \
     -v "${OUT_DIR}":/tmp/radar-output \

--- a/scanners/semgrep/run.sh
+++ b/scanners/semgrep/run.sh
@@ -19,4 +19,4 @@ docker run --rm \
     -v "${CFG_DIR}":/tmp/radar-input \
     -v "${OUT_DIR}":/tmp/radar-output \
     -e SEMGREP_APP_TOKEN="${SEMGREP_APP_TOKEN}" \
-    ghcr.io/eurekadevsecops/semgrep
+    ghcr.io/eurekadevsecops/radar-semgrep 2>&1


### PR DESCRIPTION
Allows the semgrep scanner run to be interrupted with Cmd+C. And uses the correct semgrep image name with radar- prefix.