### PR TITLE
refactor(PE-1161): support attack scenario pipeline policy flag & exit code status

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,9 @@ If no target is specified, the current working directory is scanned.
 | `-l, --local`      | Run a local scan (don't upload scan findings to Eureka).                                            |
 | `--disable-analytics` | Disable analytics for this command run.                                                          |
 | `--skip-sbom`      | Skip SBOM generation.                                                                               |
+| `-p, --pipeline-policy` | Choose `scenarios`, `vulnerability`, or `all`. Defaults to `all` for uploaded scans and `vulnerability` for local scans. |
+| `-t, --threshold` | Minimum vulnerability severity for exit code `8`: `high`, `moderate`, or `low`. When omitted, any vulnerability matches. |
+| `-a, --scenario-threshold` | Minimum active attack-scenario level for exit code `8`: `critical`, `high` (default), `moderate`, or `low`. |
 
 **PARAMETERS**
 
@@ -195,13 +198,21 @@ Radar CLI generates a CycloneDX SBOM after scanners complete and includes it in 
 
 #### Exit Codes
 
-An exit code of `0` means the scan passed with no issues. Any other code means the scan failed — either due to new vulnerabilities found or an error during the scanning process.
+An exit code of `0` means the scan completed and its configured pipeline criteria were not met. Exit code `8` means the scan completed but its configured vulnerability or attack-scenario criteria were met. Other non-zero codes indicate invalid input or a scanning error.
+
+Remote scans default to evaluating both vulnerabilities and attack scenarios: matching either threshold returns exit code `8`. 
+
+Use `--pipeline-policy=vulnerability` for vulnerability-only behavior or `--pipeline-policy=scenarios` for scenario-only behavior. 
+`--threshold` only applies when the policy includes vulnerabilities; when omitted, any vulnerability returns exit code `8`, preserving the existing behavior. 
+`--scenario-threshold` only applies when the policy includes scenarios and defaults to `high`. 
+
+Attack scenarios will not be generated from a local scan. 
 
 | Code    | Meaning                                 |
 | ------- | --------------------------------------- |
-| `0`     | Clean and successful scan.              |
+| `0`     | Successful scan; exit criteria not met. |
 | `1`     | Invalid command, arguments, or options. |
-| `8–15`  | New vulnerabilities found.              |
+| `8`     | Configured exit criteria met.           |
 | `>=16`  | Aborted due to unexpected error.        |
 
 #### Examples

--- a/cli.js
+++ b/cli.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+require('colors')
 const path = require('node:path')
 const analytics = require(path.join(__dirname, 'src', 'analytics'))
 const commands = require(path.join(__dirname, 'src', 'commands'))

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "scripts": {
     "commit": "npx cz",
     "prepare": "husky || true",
-    "test": "standard"
+    "test": "standard",
+    "test:unit": "node --test --test-reporter=spec test/*.test.js"
   },
   "repository": {
     "type": "git",

--- a/src/commands/scan.js
+++ b/src/commands/scan.js
@@ -88,7 +88,7 @@ module.exports = {
     exit code when the pipeline policy includes vulnerabilities. For example,
     setting THRESHOLD to "high" would result in a non-zero exit code only if high
     or critical vulnerabilities were found by the scan. Available values are low,
-    moderate, high, and critical - or note, warning, and error if using the SARIF
+    moderate, and high - or note, warning, and error if using the SARIF
     native severity levels. When omitted, any vulnerability returns a non-zero exit
     code, preserving the existing behavior.
 
@@ -172,7 +172,7 @@ module.exports = {
     const useAttackScenarios = args.PIPELINE_POLICY !== 'vulnerability'
     const useVulnerabilities = args.PIPELINE_POLICY !== 'scenarios'
     if (useVulnerabilities && args.THRESHOLD) {
-      if (args.FORMAT === 'security' && !['critical', 'high', 'moderate', 'low'].includes(args.THRESHOLD)) throw new Error(`THRESHOLD must be one of 'critical', 'high', 'moderate' or 'low'`)
+      if (args.FORMAT === 'security' && !['high', 'moderate', 'low'].includes(args.THRESHOLD)) throw new Error('THRESHOLD must be one of \'high\', \'moderate\' or \'low\'')
       if (args.FORMAT === 'sarif' && !['error', 'warning', 'note'].includes(args.THRESHOLD)) throw new Error(`THRESHOLD must be one of 'error', 'warning' or 'note'`)
     }
     if (useAttackScenarios && !['critical', 'high', 'moderate', 'low'].includes(args.SCENARIO_THRESHOLD)) {

--- a/src/commands/scan.js
+++ b/src/commands/scan.js
@@ -94,7 +94,7 @@ module.exports = {
 
     PIPELINE_POLICY controls whether vulnerabilities, attack scenarios, or both
     determine the exit code. Available values are "scenarios", "vulnerability",
-    and "all". It defaults to "all". Scenario criteria require a remote scan.
+    and "all". Attack scenarios will not be created for a local scan and will default to use a vulnerability policy. 
 
     SCENARIO_THRESHOLD controls the minimum active attack-scenario exploitability
     level that returns a non-zero exit code. It defaults to "high". Available
@@ -137,7 +137,7 @@ module.exports = {
     args.CATEGORIES ??= 'all'
     args.SCANNERS ??= ''
     args.DISABLE_ANALYTICS ??= false
-    args.PIPELINE_POLICY ??= 'all'
+    args.PIPELINE_POLICY ??= !telemetry.enabled || args.LOCAL ? 'vulnerability' : 'all'
     args.SCENARIO_THRESHOLD ??= 'high'
 
     // Configure analytics for this run.

--- a/src/commands/scan.js
+++ b/src/commands/scan.js
@@ -8,18 +8,11 @@ const SBOM = require('../util/sbom')
 const { execFileSync } = require('node:child_process')
 const parseDiff = require('../util/git/diff')
 const { DateTime } = require('luxon')
-
-function is_error(threshold) {
-  return is_warning(threshold) || threshold === 'high' || threshold === 'error'
-}
-
-function is_warning(threshold) {
-  return is_note(threshold) || threshold === 'moderate' || threshold === 'warning'
-}
-
-function is_note(threshold) {
-  return threshold === 'low' || threshold === 'note'
-}
+const { hasAttackScenariosAtThreshold, hasVulnerabilitiesAtThreshold } = require('../util/thresholds')
+const pollAttackScenarioSummary = require('../util/poll_attack_scenario_summary')
+const displayAttackScenarios = require('../util/display_attack_scenarios')
+const displayAttackScenarioTotals = require('../util/display_attack_scenario_totals')
+const displaySectionHeading = require('../util/display_section_heading')
 
 module.exports = {
   summary: 'scan for vulnerabilities',
@@ -40,12 +33,14 @@ module.exports = {
     { name: 'ID', short: 'i', long: 'id', type: 'string', description: 'scan ID to associate results with' },
     { name: 'LOCAL', short: 'l', long: 'local', type: 'boolean', description: 'local scan (no upload of findings to Eureka)' },
     { name: 'DISABLE_ANALYTICS', short: 'noa', long: 'disable-analytics', type: 'boolean', description: 'disable analytics for this run' },
+    { name: 'PIPELINE_POLICY', short: 'p', long: 'pipeline-policy', type: 'string', description: 'pipeline policy: scenarios, vulnerability, or all' },
     { name: 'OUTPUT', short: 'o', long: 'output', type: 'string', description: 'output SARIF file' },
     { name: 'QUIET', short: 'q', long: 'quiet', type: 'boolean', description: 'suppress stdout logging' },
+    { name: 'SCENARIO_THRESHOLD', short: 'a', long: 'scenario-threshold', type: 'string', description: 'attack-scenario threshold for non-zero exit code' },
     { name: 'SCANNERS', short: 's', long: 'scanners', type: 'string', description: 'list of scanners to use' },
     { name: 'SKIP_SBOM', short: 'B', long: 'skipSbom', type: 'bool', description: 'skip SBOM generation' },
     { name: 'DIFF', short: 'g', long: 'diff', type: 'string', description: 'base ref to filter findings by changed lines (e.g. main)' },
-    { name: 'THRESHOLD', short: 't', long: 'threshold', type: 'string', description: 'severity threshold for non-zero exit code' }
+    { name: 'THRESHOLD', short: 't', long: 'threshold', type: 'string', description: 'vulnerability severity threshold for non-zero exit code' }
   ],
   description: `
     Scans a target for vulnerabilities. Defaults to displaying findings on stdout.
@@ -91,16 +86,26 @@ module.exports = {
     Radar CLI from uploading scan findings even when you have 'EUREKA_AGENT_TOKEN' set,
     you can pass the LOCAL option on the command line.
 
-    Use the THRESHOLD option to return a non-zero exit code for severities at or
-    above the threshold. For example, setting THRESHOLD to "high" would result in
-    a non-zero exit code only if high or critical vulnerabilities were found by the
-    scan. Available values are low, moderate, high, and critical - or note, warning,
-    and error if using the SARIF native severity levels.
+    THRESHOLD controls the minimum vulnerability severity that returns a non-zero
+    exit code when the pipeline policy includes vulnerabilities. For example,
+    setting THRESHOLD to "high" would result in a non-zero exit code only if high
+    or critical vulnerabilities were found by the scan. Available values are low,
+    moderate, high, and critical - or note, warning, and error if using the SARIF
+    native severity levels. When omitted, any vulnerability returns a non-zero exit
+    code, preserving the existing behavior.
+
+    PIPELINE_POLICY controls whether vulnerabilities, attack scenarios, or both
+    determine the exit code. Available values are "scenarios", "vulnerability",
+    and "all". It defaults to "all". Scenario criteria require a remote scan.
+
+    SCENARIO_THRESHOLD controls the minimum active attack-scenario exploitability
+    level that returns a non-zero exit code. It defaults to "high". Available
+    values are low, moderate, high, and critical.
 
     Exit codes:
-         0 - Clean and successful scan. No vulnerabilities.
+         0 - Successful scan. Configured exit-code criteria not met.
          1 - Bad command, arguments, or options. Scan not completed.
-         8 - Scan completed with vulnerabilities (>= THRESHOLD severity, if set).
+         8 - Scan completed and configured exit-code criteria met.
      >= 16 - Scan aborted due to unexpected error.
   `,
   examples: [
@@ -117,7 +122,10 @@ module.exports = {
     '$ radar scan -c sca,sast -s all ' + '(use all scanners from given categories)'.grey,
     '$ radar scan -c sast -s opengrep ' + '(use only the opengrep scanner)'.grey,
     '$ radar scan -e moderate,low ' + '(treat moderate and low severities as high)'.grey,
-    '$ radar scan -t moderate ' + '(non-zero exit code for severities moderate and higher)'.grey,
+    '$ radar scan -t moderate ' + '(fail for moderate and higher vulnerabilities)'.grey,
+    '$ radar scan --scenario-threshold moderate ' + '(fail for moderate and higher attack scenarios)'.grey,
+    '$ radar scan --pipeline-policy scenarios ' + '(evaluate only attack scenarios)'.grey,
+    '$ radar scan --pipeline-policy vulnerability ' + '(evaluate only vulnerabilities)'.grey
   ],
   run: async (toolbox, args, globals) => {
     const { log, scanners: availableScanners, categories: availableCategories, telemetry, git, analytics } = toolbox
@@ -131,6 +139,8 @@ module.exports = {
     args.CATEGORIES ??= 'all'
     args.SCANNERS ??= ''
     args.DISABLE_ANALYTICS ??= false
+    args.PIPELINE_POLICY ??= 'all'
+    args.SCENARIO_THRESHOLD ??= 'high'
 
     // Configure analytics for this run.
     analytics.setEnabled(!args.DISABLE_ANALYTICS)
@@ -158,9 +168,20 @@ module.exports = {
       if (args.FORMAT === 'security' && severity !== 'moderate' && severity !== 'low') throw new Error(`Severity to escalate must be 'moderate' or 'low'`)
       if (args.FORMAT === 'sarif' && severity !== 'warning' && severity !== 'note') throw new Error(`Severity to escalate must be 'warning' or 'note'`)
     })
-    if (args.THRESHOLD) {
+    if (!['scenarios', 'vulnerability', 'all'].includes(args.PIPELINE_POLICY)) {
+      throw new Error('PIPELINE_POLICY must be one of \'scenarios\', \'vulnerability\' or \'all\'')
+    }
+    const useAttackScenarios = args.PIPELINE_POLICY !== 'vulnerability'
+    const useVulnerabilities = args.PIPELINE_POLICY !== 'scenarios'
+    if (useVulnerabilities && args.THRESHOLD) {
       if (args.FORMAT === 'security' && !['critical', 'high', 'moderate', 'low'].includes(args.THRESHOLD)) throw new Error(`THRESHOLD must be one of 'critical', 'high', 'moderate' or 'low'`)
       if (args.FORMAT === 'sarif' && !['error', 'warning', 'note'].includes(args.THRESHOLD)) throw new Error(`THRESHOLD must be one of 'error', 'warning' or 'note'`)
+    }
+    if (useAttackScenarios && !['critical', 'high', 'moderate', 'low'].includes(args.SCENARIO_THRESHOLD)) {
+      throw new Error('SCENARIO_THRESHOLD must be one of \'critical\', \'high\', \'moderate\' or \'low\'')
+    }
+    if (useAttackScenarios && (!telemetry.enabled || args.LOCAL)) {
+      throw new Error(`PIPELINE_POLICY '${args.PIPELINE_POLICY}' requires a remote scan with EUREKA_AGENT_TOKEN set`)
     }
 
     // Derive scan parameters.
@@ -315,11 +336,29 @@ module.exports = {
 
       // Analyze scan results: group findings by severity level.
       let summary
+      let scenarioSummary
       if (telemetry.enabled && scanID && !args.LOCAL) {
         const analysis = await telemetry.receiveSensitive(`scans/:scanID/summary`, { scanID })
         if (!analysis?.findingsBySeverity) throw new Error(`Failed to retrieve analysis summary for scan '${scanID}'`)
         summary = analysis.findingsBySeverity
+
+        if (useAttackScenarios) {
+          const attackScenarioSummary = await pollAttackScenarioSummary({
+            receiveSummary: () => telemetry.receiveSensitive('scans/:scanID/scenarios/summary', { scanID }),
+            onPoll: args.DEBUG
+              ? ({ attempt, intervalMs, status }) => {
+                  if (status === 'pending') log(`DEBUG: Attack scenario summary pending (attempt ${attempt}); polling again in ${intervalMs / 1000}s.`)
+                  if (status === 'completed') log(`DEBUG: Attack scenario summary completed after ${attempt} attempt${attempt === 1 ? '' : 's'}.`)
+                }
+              : undefined
+          })
+          scenarioSummary = attackScenarioSummary?.byScoreSeverity
+          if (['critical', 'high', 'moderate', 'low'].some((level) => !Array.isArray(scenarioSummary?.[level]))) {
+            throw new Error(`Failed to retrieve attack scenario summary for scan '${scanID}'`)
+          }
+        }
       } else {
+        if (useAttackScenarios) throw new Error(`Failed to retrieve attack scenario summary for scan '${scanID}'`)
         summary = await SARIF.analysis.summarize(results.sarif, target)
       }
 
@@ -331,31 +370,34 @@ module.exports = {
 
       // Display summarized findings.
       if (!args.QUIET) {
-        log()
-        SARIF.visualizations.display_findings(summary, args.FORMAT, log)
+        const hasVulnerabilities = summary.errors.length > 0 || summary.warnings.length > 0 || summary.notes.length > 0
+        const hasAttackScenarios = useAttackScenarios && Object.values(scenarioSummary).some((scenarios) => scenarios.length > 0)
+        if (hasVulnerabilities) {
+          log()
+          displaySectionHeading('Vulnerabilities', log)
+          SARIF.visualizations.display_findings(summary, args.FORMAT, log)
+        }
         if (outfile) log(`Findings exported to ${outfile}`)
+        if (hasAttackScenarios) {
+          log()
+          displayAttackScenarios(scenarioSummary, log)
+        }
+        log()
         SARIF.visualizations.display_totals(summary, args.FORMAT, log, telemetry.enabled && scanID && !args.LOCAL)
+        if (useAttackScenarios) displayAttackScenarioTotals(scenarioSummary, log)
       }
 
       // Display link to scan results in the dashboard.
       if (telemetry.enabled && scanURL && !args.QUIET) {
+        log()
         log(`View scan findings in the Eureka dashboard: ${scanURL}`)
       }
 
       // Determine the correct exit code.
       let exitCode = 0
-      if (!summary.errors.length && !summary.warnings.length && !summary.notes.length) {
-        // No vulnerabilities.
-        exitCode = 0
-      } else if (args.THRESHOLD) {
-        // Set the exit code to 8 if there are any vulnerabilities with severities at or above the given threshold.
-        if (is_error(args.THRESHOLD) && summary.errors.length > 0) exitCode = 0x8
-        if (is_warning(args.THRESHOLD) && summary.warnings.length > 0) exitCode = 0x8
-        if (is_note(args.THRESHOLD) && summary.notes.length > 0) exitCode = 0x8
-      } else {
-        // Set the exit code to 8 if there are any vulnerabilities.
-        exitCode = 0x8
-      }
+      const vulnerabilityThresholdMet = useVulnerabilities && hasVulnerabilitiesAtThreshold(summary, args.THRESHOLD)
+      const scenarioThresholdMet = useAttackScenarios && hasAttackScenariosAtThreshold(scenarioSummary, args.SCENARIO_THRESHOLD)
+      if (vulnerabilityThresholdMet || scenarioThresholdMet) exitCode = 0x8
 
       analytics.track(analytics.EVENTS.radar_scan_completed, {
         flags: args,
@@ -366,7 +408,7 @@ module.exports = {
         summary
       })
 
-      // Display the exit code.
+      // Display the non-zero exit code.
       if (!args.QUIET && exitCode !== 0) {
         log(`Terminating with exit code ${exitCode}. See 'radar help scan' for list of possible exit codes.`)
       }

--- a/src/commands/scan.js
+++ b/src/commands/scan.js
@@ -169,16 +169,16 @@ module.exports = {
     if (!['scenarios', 'vulnerability', 'all'].includes(args.PIPELINE_POLICY)) {
       throw new Error('PIPELINE_POLICY must be one of \'scenarios\', \'vulnerability\' or \'all\'')
     }
-    const useAttackScenarios = args.PIPELINE_POLICY !== 'vulnerability'
+    const evaluateAttackScenarios = args.PIPELINE_POLICY !== 'vulnerability'
     const useVulnerabilities = args.PIPELINE_POLICY !== 'scenarios'
     if (useVulnerabilities && args.THRESHOLD) {
       if (args.FORMAT === 'security' && !['high', 'moderate', 'low'].includes(args.THRESHOLD)) throw new Error('THRESHOLD must be one of \'high\', \'moderate\' or \'low\'')
       if (args.FORMAT === 'sarif' && !['error', 'warning', 'note'].includes(args.THRESHOLD)) throw new Error(`THRESHOLD must be one of 'error', 'warning' or 'note'`)
     }
-    if (useAttackScenarios && !['critical', 'high', 'moderate', 'low'].includes(args.SCENARIO_THRESHOLD)) {
+    if (evaluateAttackScenarios && !['critical', 'high', 'moderate', 'low'].includes(args.SCENARIO_THRESHOLD)) {
       throw new Error('SCENARIO_THRESHOLD must be one of \'critical\', \'high\', \'moderate\' or \'low\'')
     }
-    if (useAttackScenarios && (!telemetry.enabled || args.LOCAL)) {
+    if (evaluateAttackScenarios && (!telemetry.enabled || args.LOCAL)) {
       throw new Error(`PIPELINE_POLICY '${args.PIPELINE_POLICY}' requires a remote scan with EUREKA_AGENT_TOKEN set`)
     }
 
@@ -340,23 +340,21 @@ module.exports = {
         if (!analysis?.findingsBySeverity) throw new Error(`Failed to retrieve analysis summary for scan '${scanID}'`)
         summary = analysis.findingsBySeverity
 
-        if (useAttackScenarios) {
-          const attackScenarioSummary = await pollAttackScenarioSummary({
-            receiveSummary: () => telemetry.receiveSensitive('scans/:scanID/scenarios/summary', { scanID }),
-            onPoll: args.DEBUG
-              ? ({ attempt, intervalMs, status }) => {
-                  if (status === 'pending') log(`DEBUG: Attack scenario summary pending (attempt ${attempt}); polling again in ${intervalMs / 1000}s.`)
-                  if (status === 'completed') log(`DEBUG: Attack scenario summary completed after ${attempt} attempt${attempt === 1 ? '' : 's'}.`)
-                }
-              : undefined
-          })
-          scenarioSummary = attackScenarioSummary?.byScoreSeverity
-          if (['critical', 'high', 'moderate', 'low'].some((level) => !Array.isArray(scenarioSummary?.[level]))) {
-            throw new Error(`Failed to retrieve attack scenario summary for scan '${scanID}'`)
-          }
+        const attackScenarioSummary = await pollAttackScenarioSummary({
+          receiveSummary: () => telemetry.receiveSensitive('scans/:scanID/scenarios/summary', { scanID }),
+          onPoll: args.DEBUG
+            ? ({ attempt, intervalMs, status }) => {
+                if (status === 'pending') log(`DEBUG: Attack scenario summary pending (attempt ${attempt}); polling again in ${intervalMs / 1000}s.`)
+                if (status === 'completed') log(`DEBUG: Attack scenario summary completed after ${attempt} attempt${attempt === 1 ? '' : 's'}.`)
+              }
+            : undefined
+        })
+        scenarioSummary = attackScenarioSummary?.byScoreSeverity
+        if (['critical', 'high', 'moderate', 'low'].some((level) => !Array.isArray(scenarioSummary?.[level]))) {
+          throw new Error(`Failed to retrieve attack scenario summary for scan '${scanID}'`)
         }
       } else {
-        if (useAttackScenarios) throw new Error(`Failed to retrieve attack scenario summary for scan '${scanID}'`)
+        if (evaluateAttackScenarios) throw new Error(`Failed to retrieve attack scenario summary for scan '${scanID}'`)
         summary = await SARIF.analysis.summarize(results.sarif, target)
       }
 
@@ -371,7 +369,7 @@ module.exports = {
         displayScanResults({
           summary,
           scenarioSummary,
-          useAttackScenarios,
+          useAttackScenarios: Boolean(scenarioSummary),
           outfile,
           format: args.FORMAT,
           baselined: telemetry.enabled && scanID && !args.LOCAL,

--- a/src/commands/scan.js
+++ b/src/commands/scan.js
@@ -8,11 +8,9 @@ const SBOM = require('../util/sbom')
 const { execFileSync } = require('node:child_process')
 const parseDiff = require('../util/git/diff')
 const { DateTime } = require('luxon')
-const { hasAttackScenariosAtThreshold, hasVulnerabilitiesAtThreshold } = require('../util/thresholds')
 const pollAttackScenarioSummary = require('../util/poll_attack_scenario_summary')
-const displayAttackScenarios = require('../util/display_attack_scenarios')
-const displayAttackScenarioTotals = require('../util/display_attack_scenario_totals')
-const displaySectionHeading = require('../util/display_section_heading')
+const displayScanResults = require('../util/display_scan_results')
+const pipelineExitCode = require('../util/pipeline_exit_code')
 
 module.exports = {
   summary: 'scan for vulnerabilities',
@@ -370,34 +368,26 @@ module.exports = {
 
       // Display summarized findings.
       if (!args.QUIET) {
-        const hasVulnerabilities = summary.errors.length > 0 || summary.warnings.length > 0 || summary.notes.length > 0
-        const hasAttackScenarios = useAttackScenarios && Object.values(scenarioSummary).some((scenarios) => scenarios.length > 0)
-        if (hasVulnerabilities) {
-          log()
-          displaySectionHeading('Vulnerabilities', log)
-          SARIF.visualizations.display_findings(summary, args.FORMAT, log)
-        }
-        if (outfile) log(`Findings exported to ${outfile}`)
-        if (hasAttackScenarios) {
-          log()
-          displayAttackScenarios(scenarioSummary, log)
-        }
-        log()
-        SARIF.visualizations.display_totals(summary, args.FORMAT, log, telemetry.enabled && scanID && !args.LOCAL)
-        if (useAttackScenarios) displayAttackScenarioTotals(scenarioSummary, log)
-      }
-
-      // Display link to scan results in the dashboard.
-      if (telemetry.enabled && scanURL && !args.QUIET) {
-        log()
-        log(`View scan findings in the Eureka dashboard: ${scanURL}`)
+        displayScanResults({
+          summary,
+          scenarioSummary,
+          useAttackScenarios,
+          outfile,
+          format: args.FORMAT,
+          baselined: telemetry.enabled && scanID && !args.LOCAL,
+          scanURL: telemetry.enabled && scanID && !args.LOCAL ? scanURL : undefined,
+          log
+        })
       }
 
       // Determine the correct exit code.
-      let exitCode = 0
-      const vulnerabilityThresholdMet = useVulnerabilities && hasVulnerabilitiesAtThreshold(summary, args.THRESHOLD)
-      const scenarioThresholdMet = useAttackScenarios && hasAttackScenariosAtThreshold(scenarioSummary, args.SCENARIO_THRESHOLD)
-      if (vulnerabilityThresholdMet || scenarioThresholdMet) exitCode = 0x8
+      const exitCode = pipelineExitCode({
+        policy: args.PIPELINE_POLICY,
+        vulnerabilitySummary: summary,
+        vulnerabilityThreshold: args.THRESHOLD,
+        scenarioSummary,
+        scenarioThreshold: args.SCENARIO_THRESHOLD
+      })
 
       analytics.track(analytics.EVENTS.radar_scan_completed, {
         flags: args,

--- a/src/telemetry/index.js
+++ b/src/telemetry/index.js
@@ -151,6 +151,7 @@ class Telemetry {
     const claims = this.#claims(token ?? this.#EUREKA_AGENT_TOKEN)
     const aud = claims.aud.replace(/\/$/, '')
     if (path === `scans/:scanID/summary`) return `${aud}/scans/${params.scanID}/summary`
+    if (path === 'scans/:scanID/scenarios/summary') return `${aud}/scans/${params.scanID}/scenarios/summary`
     throw new Error(`Internal Error: Unknown telemetry event: GET ${path}`)
   }
 

--- a/src/util/display_attack_scenario_totals.js
+++ b/src/util/display_attack_scenario_totals.js
@@ -1,0 +1,9 @@
+module.exports = (summary, log) => {
+  const counts = Object.fromEntries(Object.entries(summary).map(([severity, scenarios]) => [severity, scenarios.length]))
+  const total = Object.values(counts).reduce((sum, count) => sum + count, 0)
+  const critical = `${counts.critical} ${'critical'.red.bold}`
+  const high = `${counts.high} ${'high'.red.bold}`
+  const moderate = `${counts.moderate} ${'moderate'.yellow.bold}`
+  const low = `${counts.low} low`
+  log(`${total} attack scenario${total === 1 ? '' : 's'} discovered: ${critical}, ${high}, ${moderate}, ${low}.`)
+}

--- a/src/util/display_attack_scenarios.js
+++ b/src/util/display_attack_scenarios.js
@@ -1,0 +1,21 @@
+const displaySectionHeading = require('./display_section_heading')
+
+const severities = ['critical', 'high', 'moderate', 'low']
+
+function formatBySeverity (value, severity) {
+  const label = `${value}`
+  if (severity === 'critical' || severity === 'high') return label.bold.red
+  if (severity === 'moderate') return label.bold.yellow
+  return label.bold
+}
+
+module.exports = (summary, log) => {
+  displaySectionHeading('Attack Scenarios', log)
+
+  for (const severity of severities) {
+    for (const scenario of summary[severity]) {
+      const score = scenario.exploitabilityScore === null ? 'unscored' : scenario.exploitabilityScore
+      log(`${formatBySeverity(severity, severity)} attack scenario: exploitability ${formatBySeverity(score, severity)}: ${scenario.name}\n`)
+    }
+  }
+}

--- a/src/util/display_scan_results.js
+++ b/src/util/display_scan_results.js
@@ -1,0 +1,28 @@
+const displayFindings = require('./sarif/visualizations/display_findings')
+const displayTotals = require('./sarif/visualizations/display_totals')
+const displayAttackScenarios = require('./display_attack_scenarios')
+const displayAttackScenarioTotals = require('./display_attack_scenario_totals')
+const displaySectionHeading = require('./display_section_heading')
+
+module.exports = ({ summary, scenarioSummary, useAttackScenarios, outfile, format, baselined, scanURL, log }) => {
+  const hasVulnerabilities = summary.errors.length > 0 || summary.warnings.length > 0 || summary.notes.length > 0
+  const hasAttackScenarios = useAttackScenarios && Object.values(scenarioSummary).some((scenarios) => scenarios.length > 0)
+
+  if (hasVulnerabilities) {
+    log()
+    displaySectionHeading('Vulnerabilities', log)
+    displayFindings(summary, format, log)
+  }
+  if (outfile) log(`Findings exported to ${outfile}`)
+  if (hasAttackScenarios) {
+    log()
+    displayAttackScenarios(scenarioSummary, log)
+  }
+  log()
+  displayTotals(summary, format, log, baselined)
+  if (useAttackScenarios) displayAttackScenarioTotals(scenarioSummary, log)
+  if (scanURL) {
+    log()
+    log(`View scan findings in the Eureka dashboard: ${scanURL}`)
+  }
+}

--- a/src/util/display_section_heading.js
+++ b/src/util/display_section_heading.js
@@ -1,0 +1,7 @@
+const WIDTH = 64
+
+module.exports = (title, log) => {
+  log(title)
+  log('─'.repeat(WIDTH))
+  log()
+}

--- a/src/util/pipeline_exit_code.js
+++ b/src/util/pipeline_exit_code.js
@@ -1,0 +1,7 @@
+const { hasAttackScenariosAtThreshold, hasVulnerabilitiesAtThreshold } = require('./thresholds')
+
+module.exports = ({ policy, vulnerabilitySummary, vulnerabilityThreshold, scenarioSummary, scenarioThreshold }) => {
+  const vulnerabilityThresholdMet = policy !== 'scenarios' && hasVulnerabilitiesAtThreshold(vulnerabilitySummary, vulnerabilityThreshold)
+  const scenarioThresholdMet = policy !== 'vulnerability' && hasAttackScenariosAtThreshold(scenarioSummary, scenarioThreshold)
+  return vulnerabilityThresholdMet || scenarioThresholdMet ? 0x8 : 0
+}

--- a/src/util/poll_attack_scenario_summary.js
+++ b/src/util/poll_attack_scenario_summary.js
@@ -1,0 +1,30 @@
+const POLL_INTERVAL_MS = 5000
+const POLL_TIMEOUT_MS = 5 * 60 * 1000
+
+const wait = (duration) => new Promise((resolve) => setTimeout(resolve, duration))
+
+module.exports = async ({ receiveSummary, onPoll, intervalMs = POLL_INTERVAL_MS, timeoutMs = POLL_TIMEOUT_MS }) => {
+  const startedAt = Date.now()
+  let attempt = 1
+
+  while (true) {
+    const response = await receiveSummary()
+
+    if (response?.status === 'completed') {
+      onPoll?.({ attempt, status: 'completed' })
+      return response.summary
+    }
+
+    if (response?.status !== 'pending') {
+      throw new Error('Received an invalid attack scenario summary polling response')
+    }
+
+    if (Date.now() - startedAt >= timeoutMs) {
+      throw new Error(`Timed out waiting for attack scenario summary after ${timeoutMs}ms`)
+    }
+
+    onPoll?.({ attempt, intervalMs, status: 'pending' })
+    await wait(intervalMs)
+    attempt++
+  }
+}

--- a/src/util/thresholds.js
+++ b/src/util/thresholds.js
@@ -1,0 +1,36 @@
+function isError (threshold) {
+  return isWarning(threshold) || threshold === 'high' || threshold === 'error'
+}
+
+function isWarning (threshold) {
+  return isNote(threshold) || threshold === 'moderate' || threshold === 'warning'
+}
+
+function isNote (threshold) {
+  return threshold === 'low' || threshold === 'note'
+}
+
+function hasVulnerabilitiesAtThreshold (summary, threshold) {
+  if (!summary.errors.length && !summary.warnings.length && !summary.notes.length) return false
+  if (!threshold) return true
+
+  if (isError(threshold) && summary.errors.length > 0) return true
+  if (isWarning(threshold) && summary.warnings.length > 0) return true
+  if (isNote(threshold) && summary.notes.length > 0) return true
+  return false
+}
+
+function hasAttackScenariosAtThreshold (summary, threshold) {
+  if (summary.critical.length > 0) return true
+  if (threshold === 'critical') return false
+  if (summary.high.length > 0) return true
+  if (threshold === 'high') return false
+  if (summary.moderate.length > 0) return true
+  if (threshold === 'moderate') return false
+  return summary.low.length > 0
+}
+
+module.exports = {
+  hasAttackScenariosAtThreshold,
+  hasVulnerabilitiesAtThreshold
+}

--- a/test/display_scan_results.test.js
+++ b/test/display_scan_results.test.js
@@ -1,0 +1,93 @@
+const assert = require('node:assert/strict')
+const test = require('node:test')
+const colors = require('colors')
+
+const displayScanResults = require('../src/util/display_scan_results')
+
+colors.disable()
+
+const emptyVulnerabilities = () => ({ errors: [], warnings: [], notes: [] })
+const emptyScenarios = () => ({ critical: [], high: [], moderate: [], low: [] })
+
+function capture (overrides = {}) {
+  const lines = []
+  displayScanResults({
+    summary: emptyVulnerabilities(),
+    scenarioSummary: emptyScenarios(),
+    useAttackScenarios: true,
+    format: 'security',
+    baselined: true,
+    log: (...args) => lines.push(args.join(' ')),
+    ...overrides
+  })
+  return { lines, output: lines.join('\n') }
+}
+
+test('hides empty vulnerability and attack-scenario sections', () => {
+  const { output } = capture()
+
+  assert.doesNotMatch(output, /^Vulnerabilities$/m)
+  assert.doesNotMatch(output, /^Attack Scenarios$/m)
+  assert.match(output, /0 new vulnerabilities:/)
+  assert.match(output, /0 attack scenarios discovered:/)
+})
+
+test('shows only the vulnerability section when scenarios are empty', () => {
+  const { output } = capture({
+    summary: {
+      errors: [{ artifact: { name: 'app.js', line: 4 }, tool: 'scanner', message: 'unsafe call' }],
+      warnings: [],
+      notes: []
+    }
+  })
+
+  assert.match(output, /^Vulnerabilities\n─+\n/m)
+  assert.match(output, /app\.js:4: high severity: scanner: unsafe call/)
+  assert.doesNotMatch(output, /^Attack Scenarios$/m)
+})
+
+test('shows scenario names and exploitability without IDs or status', () => {
+  const { output } = capture({
+    scenarioSummary: {
+      critical: [{
+        id: 'scenario-id',
+        friendlyId: 'AS-1',
+        name: 'Account takeover',
+        status: 'open',
+        exploitabilityScore: 95
+      }],
+      high: [],
+      moderate: [],
+      low: []
+    }
+  })
+
+  assert.match(output, /^Attack Scenarios\n─+\n/m)
+  assert.match(output, /critical attack scenario: exploitability 95: Account takeover/)
+  assert.doesNotMatch(output, /AS-1|scenario-id|\bopen\b/)
+})
+
+test('groups both totals at the end and leaves a blank line before the dashboard link', () => {
+  const { lines } = capture({
+    summary: {
+      errors: [{ artifact: { name: 'app.js', line: 4 }, tool: 'scanner', message: 'unsafe call' }],
+      warnings: [],
+      notes: []
+    },
+    scenarioSummary: {
+      critical: [{ name: 'Account takeover', exploitabilityScore: 95 }],
+      high: [],
+      moderate: [],
+      low: []
+    },
+    scanURL: 'https://example.test/scans/scan-id'
+  })
+  const scenario = lines.findIndex((line) => line.includes('Account takeover'))
+  const vulnerabilityTotal = lines.findIndex((line) => line.includes('1 new vulnerability:'))
+  const scenarioTotal = lines.findIndex((line) => line.includes('1 attack scenario discovered:'))
+  const link = lines.findIndex((line) => line.startsWith('View scan findings'))
+
+  assert.ok(vulnerabilityTotal > scenario)
+  assert.equal(scenarioTotal, vulnerabilityTotal + 1)
+  assert.equal(lines[link - 1], '')
+})

--- a/test/pipeline_exit_code.test.js
+++ b/test/pipeline_exit_code.test.js
@@ -1,0 +1,197 @@
+const assert = require('node:assert/strict')
+const test = require('node:test')
+
+const pipelineExitCode = require('../src/util/pipeline_exit_code')
+
+const emptyVulnerabilities = () => ({ errors: [], warnings: [], notes: [] })
+const emptyScenarios = () => ({ critical: [], high: [], moderate: [], low: [] })
+
+const sourceCases = [
+  { name: 'neither source matches', vulnerabilities: false, scenarios: false },
+  { name: 'only vulnerabilities match', vulnerabilities: true, scenarios: false },
+  { name: 'only scenarios match', vulnerabilities: false, scenarios: true },
+  { name: 'both sources match', vulnerabilities: true, scenarios: true }
+]
+
+const expectedByPolicy = {
+  vulnerability: [0, 8, 0, 8],
+  scenarios: [0, 0, 8, 8],
+  all: [0, 8, 8, 8]
+}
+
+for (const [policy, expectedExitCodes] of Object.entries(expectedByPolicy)) {
+  for (const [index, sourceCase] of sourceCases.entries()) {
+    const expectedExitCode = expectedExitCodes[index]
+    test(`${policy} policy with ${sourceCase.name} returns exit code ${expectedExitCode}`, () => {
+      const exitCode = pipelineExitCode({
+        policy,
+        vulnerabilitySummary: {
+          ...emptyVulnerabilities(),
+          errors: sourceCase.vulnerabilities ? [{}] : []
+        },
+        vulnerabilityThreshold: 'high',
+        scenarioSummary: {
+          ...emptyScenarios(),
+          high: sourceCase.scenarios ? [{}] : []
+        },
+        scenarioThreshold: 'high'
+      })
+
+      assert.equal(exitCode, expectedExitCode)
+    })
+  }
+}
+
+const thresholdCases = [
+  {
+    name: 'vulnerability policy with moderate finding and high threshold returns exit code 0',
+    args: {
+      policy: 'vulnerability',
+      vulnerabilitySummary: { ...emptyVulnerabilities(), warnings: [{}] },
+      vulnerabilityThreshold: 'high'
+    },
+    expectedExitCode: 0
+  },
+  {
+    name: 'vulnerability policy with moderate finding and moderate threshold returns exit code 8',
+    args: {
+      policy: 'vulnerability',
+      vulnerabilitySummary: { ...emptyVulnerabilities(), warnings: [{}] },
+      vulnerabilityThreshold: 'moderate'
+    },
+    expectedExitCode: 8
+  },
+  {
+    name: 'scenarios policy with high scenario and critical threshold returns exit code 0',
+    args: {
+      policy: 'scenarios',
+      vulnerabilitySummary: emptyVulnerabilities(),
+      scenarioSummary: { ...emptyScenarios(), high: [{}] },
+      scenarioThreshold: 'critical'
+    },
+    expectedExitCode: 0
+  },
+  {
+    name: 'scenarios policy with high scenario and high threshold returns exit code 8',
+    args: {
+      policy: 'scenarios',
+      vulnerabilitySummary: emptyVulnerabilities(),
+      scenarioSummary: { ...emptyScenarios(), high: [{}] },
+      scenarioThreshold: 'high'
+    },
+    expectedExitCode: 8
+  },
+  {
+    name: 'scenarios policy with high vulnerability, low scenario, and moderate threshold returns exit code 0',
+    args: {
+      policy: 'scenarios',
+      vulnerabilitySummary: { ...emptyVulnerabilities(), errors: [{}] },
+      vulnerabilityThreshold: 'high',
+      scenarioSummary: { ...emptyScenarios(), low: [{}] },
+      scenarioThreshold: 'moderate'
+    },
+    expectedExitCode: 0
+  },
+  {
+    name: 'scenarios policy with high vulnerability, low scenario, and low threshold returns exit code 8',
+    args: {
+      policy: 'scenarios',
+      vulnerabilitySummary: { ...emptyVulnerabilities(), errors: [{}] },
+      vulnerabilityThreshold: 'high',
+      scenarioSummary: { ...emptyScenarios(), low: [{}] },
+      scenarioThreshold: 'low'
+    },
+    expectedExitCode: 8
+  },
+  {
+    name: 'vulnerability policy with low vulnerability, critical scenario, and moderate threshold returns exit code 0',
+    args: {
+      policy: 'vulnerability',
+      vulnerabilitySummary: { ...emptyVulnerabilities(), notes: [{}] },
+      vulnerabilityThreshold: 'moderate',
+      scenarioSummary: { ...emptyScenarios(), critical: [{}] },
+      scenarioThreshold: 'critical'
+    },
+    expectedExitCode: 0
+  },
+  {
+    name: 'vulnerability policy with low vulnerability, critical scenario, and low threshold returns exit code 8',
+    args: {
+      policy: 'vulnerability',
+      vulnerabilitySummary: { ...emptyVulnerabilities(), notes: [{}] },
+      vulnerabilityThreshold: 'low',
+      scenarioSummary: { ...emptyScenarios(), critical: [{}] },
+      scenarioThreshold: 'critical'
+    },
+    expectedExitCode: 8
+  },
+  {
+    name: 'all policy exits when only the scenario threshold is met',
+    args: {
+      policy: 'all',
+      vulnerabilitySummary: { ...emptyVulnerabilities(), notes: [{}] },
+      vulnerabilityThreshold: 'moderate',
+      scenarioSummary: { ...emptyScenarios(), high: [{}] },
+      scenarioThreshold: 'high'
+    },
+    expectedExitCode: 8
+  },
+  {
+    name: 'all policy exits when only the vulnerability threshold is met',
+    args: {
+      policy: 'all',
+      vulnerabilitySummary: { ...emptyVulnerabilities(), errors: [{}] },
+      vulnerabilityThreshold: 'high',
+      scenarioSummary: { ...emptyScenarios(), low: [{}] },
+      scenarioThreshold: 'moderate'
+    },
+    expectedExitCode: 8
+  },
+  {
+    name: 'all policy passes when both sources are below their thresholds',
+    args: {
+      policy: 'all',
+      vulnerabilitySummary: { ...emptyVulnerabilities(), notes: [{}] },
+      vulnerabilityThreshold: 'moderate',
+      scenarioSummary: { ...emptyScenarios(), low: [{}] },
+      scenarioThreshold: 'moderate'
+    },
+    expectedExitCode: 0
+  }
+]
+
+for (const { name, args, expectedExitCode } of thresholdCases) {
+  test(name, () => assert.equal(pipelineExitCode(args), expectedExitCode))
+}
+
+test('vulnerability policy ignores inactive scenario data and threshold', () => {
+  const exitCode = pipelineExitCode({
+    policy: 'vulnerability',
+    vulnerabilitySummary: emptyVulnerabilities(),
+    scenarioSummary: undefined,
+    scenarioThreshold: 'invalid'
+  })
+
+  assert.equal(exitCode, 0)
+})
+
+test('scenarios policy ignores inactive vulnerability data and threshold', () => {
+  const exitCode = pipelineExitCode({
+    policy: 'scenarios',
+    vulnerabilitySummary: undefined,
+    vulnerabilityThreshold: 'invalid',
+    scenarioSummary: emptyScenarios(),
+    scenarioThreshold: 'high'
+  })
+
+  assert.equal(exitCode, 0)
+})
+
+test('omitted vulnerability threshold preserves any-finding behavior', () => {
+  const exitCode = pipelineExitCode({
+    policy: 'vulnerability',
+    vulnerabilitySummary: { ...emptyVulnerabilities(), notes: [{}] }
+  })
+
+  assert.equal(exitCode, 8)
+})

--- a/test/poll_attack_scenario_summary.test.js
+++ b/test/poll_attack_scenario_summary.test.js
@@ -1,0 +1,51 @@
+const assert = require('node:assert/strict')
+const test = require('node:test')
+
+const pollAttackScenarioSummary = require('../src/util/poll_attack_scenario_summary')
+
+test('polls pending responses until the summary is completed', async () => {
+  const responses = [
+    { status: 'pending' },
+    { status: 'pending' },
+    {
+      status: 'completed',
+      summary: {
+        byStatus: { open: [], partiallyRemediated: [], remediated: [] },
+        byScoreSeverity: { critical: [], high: [], moderate: [], low: [] }
+      }
+    }
+  ]
+  const events = []
+
+  const summary = await pollAttackScenarioSummary({
+    receiveSummary: async () => responses.shift(),
+    onPoll: (event) => events.push(event),
+    intervalMs: 0,
+    timeoutMs: 100
+  })
+
+  assert.deepEqual(summary.byScoreSeverity, { critical: [], high: [], moderate: [], low: [] })
+  assert.deepEqual(events.map(({ attempt, status }) => ({ attempt, status })), [
+    { attempt: 1, status: 'pending' },
+    { attempt: 2, status: 'pending' },
+    { attempt: 3, status: 'completed' }
+  ])
+})
+
+test('rejects an invalid polling response', async () => {
+  await assert.rejects(
+    pollAttackScenarioSummary({ receiveSummary: async () => ({ status: 'unknown' }) }),
+    /invalid attack scenario summary polling response/
+  )
+})
+
+test('times out while the summary remains pending', async () => {
+  await assert.rejects(
+    pollAttackScenarioSummary({
+      receiveSummary: async () => ({ status: 'pending' }),
+      intervalMs: 0,
+      timeoutMs: 0
+    }),
+    /Timed out waiting for attack scenario summary/
+  )
+})


### PR DESCRIPTION
## Issue
Resolves PE-1161

## Changes
- Add -p/--pipeline-policy for scenarios, vulnerability, or all, with separate vulnerability and attack-scenario thresholds.
- Poll the completed scan's attack-scenario summary and include its severity results in exit code 8 decisions.
- Display vulnerability and attack-scenario findings and totals with clearer section formatting.
- Default uploaded scans to both policies and local scans to vulnerability-only behavior.
- Add unit coverage for policy and threshold exit codes, summary polling, and scan result output.

## Additional Considerations/Caveats
- Attack-scenario policies require an uploaded scan so the scenario summary can be retrieved.
- Vulnerability exit behavior remains compatible when --threshold is omitted.


https://github.com/user-attachments/assets/2f98cbba-f866-43c7-bf23-5fbd222ea6c1



